### PR TITLE
feat: add YOLO26 inference pipeline with improved display handling

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,72 @@
+# Prerequisites
+*.d
+
+# Compiled Object files
+*.slo
+*.lo
+*.o
+*.obj
+
+# Precompiled Headers
+*.gch
+*.pch
+
+# Linker files
+*.ilk
+
+# Debugger Files
+*.pdb
+
+# Compiled Dynamic libraries
+*.so
+*.dylib
+*.dll
+*.so.*
+
+
+# Fortran module files
+*.mod
+*.smod
+
+# Compiled Static libraries
+*.lai
+*.la
+*.a
+*.lib
+
+# Executables
+*.exe
+*.out
+*.app
+
+# Build directories
+build/
+Build/
+build-*/
+
+# CMake generated files
+CMakeFiles/
+CMakeCache.txt
+cmake_install.cmake
+Makefile
+install_manifest.txt 
+compile_commands.json
+
+# Temporary files
+*.tmp 
+*.log 
+*.bak 
+*.swp 
+
+# vcpkg
+vcpkg_installed/
+
+# debug information files
+*.dwo
+
+# test output & cache
+Testing/
+.cache/
+build
+mpp
+rknn-toolkit2

--- a/.gitignore
+++ b/.gitignore
@@ -70,3 +70,6 @@ Testing/
 build
 mpp
 rknn-toolkit2
+log/*
+.vscode/
+*.png

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,39 @@
+# Repository Guidelines
+
+## Project Structure & Module Organization
+- `main.cc`: demo pipeline entry; wires source, inference, tracking, OSD, broker, and destination nodes.
+- `vp_node/`: core node framework and pipeline modules (`nodes/infer`, `nodes/osd`, `nodes/track`, `nodes/broker`).
+- `videocodec/`: Rockchip-oriented decode/encode, demux/mux, and scaler components.
+- `models/`: RKNN model wrappers and post-processing (`yolo*`, `rtmpose*`, `classifier*`).
+- `tests/`: C++ sample test entry points (`main_model.cc`, `main_track.cc`, `main_record.cc`).
+- `python/`: lightweight Python inference/tracking/count demos (`test_model.py`, `test_count.py`).
+- `assets/`: configs, sample images/videos, and demo resources. Avoid committing large new media files unless required.
+
+## Build, Test, and Development Commands
+- `./build-linux.sh`: standard Linux build (creates `build/`, runs `cmake`, `make`, `make install`).
+- `cmake -S . -B build && cmake --build build -j4`: explicit out-of-source build for iteration.
+- `cmake --install build`: installs binaries/libs to `build/bin` per root `CMakeLists.txt`.
+- `build/bin/rk_videopipe`: run the default C++ demo pipeline.
+- `cd python && python3 test_model.py`: run image-based Python model smoke test.
+- `cd python && python3 test_count.py`: run video counting/tracking smoke test.
+
+## Coding Style & Naming Conventions
+- C++17 is required; follow existing style: 4-space indentation, braces on new lines for functions, and readable include grouping.
+- Use `snake_case` for variables/functions, and keep existing prefixes (`vp_`, `rk_`) for modules and classes.
+- Keep node names and config paths explicit (example: `"rk_yolo_0"`, `"assets/configs/person.json"`).
+- Edit dependency paths in `cmake/common.cmake` instead of hardcoding local paths in source files.
+
+## Testing Guidelines
+- No unified `ctest`/`gtest` suite is configured; use smoke tests from `tests/` and `python/test_*.py`.
+- Name new Python checks as `python/test_<feature>.py`.
+- For C++ changes, verify at least: build success, pipeline startup, and one sample media run from `assets/`.
+
+## Commit & Pull Request Guidelines
+- Follow current history style with short imperative subjects: `Add ...`, `Fix ...`, `Update ...`.
+- Keep subject lines concise and scoped to one change area.
+- PRs should include: purpose, affected modules (for example `vp_node/nodes/infer`), validation steps/commands, and runtime evidence (logs or screenshots for OSD/streaming changes).
+- Link related issues and clearly mark dependency or environment assumptions (RK3588 board, FFmpeg/GStreamer plugin status).
+
+## Security & Configuration Tips
+- Do not commit secrets (RTSP credentials, tokens, private endpoints) in code or config.
+- Verify third-party symlinks (`mpp`, `rknn-toolkit2`) and runtime libraries before running on new devices.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,142 @@
+# CLAUDE.md
+
+本文件为 Claude Code (claude.ai/code) 提供在此代码库中工作的指导。
+
+## 项目概述
+
+RK_VideoPipe 是一个移植到 RK3588 平台（瑞芯微 SoC）的视频分析流水线框架。它提供了硬件加速的视频处理（通过 MPP 进行编解码）、AI 推理（通过 RKNN），以及基于节点架构的计算机视觉应用构建方案。
+
+本项目基于 [VideoPipe](https://github.com/sherlockchou86/VideoPipe) 开源项目，并结合了瑞芯微的硬件加速库。
+
+## 构建命令
+
+```bash
+# 标准构建（创建 build/ 目录并编译所有内容）
+./build-linux.sh
+
+# 手动构建（用于调试构建问题）
+cmake -S . -B build
+cmake --build build -j4
+cmake --install build
+
+# 运行主程序
+build/bin/rk_videopipe
+```
+
+**注意**：交叉编译工具链设置为 `aarch64-linux-gnu`。编译器设置见 `build-linux.sh`。
+
+## 高层架构
+
+### 基于节点的流水线框架
+
+核心架构是由处理节点组成的有向无环图（DAG）：
+
+```
+源节点 -> 推理节点 -> 跟踪节点 -> 二级推理 -> OSD -> 消息代理 -> 目标节点
+```
+
+所有节点继承自 `vp_node` (vp_node/nodes/base/vp_node.h:29) 并实现：
+- `handle_frame_meta()`: 逐帧处理
+- `handle_frame_meta(batch)`: 批量处理帧（用于推理节点）
+- `meta_flow()`: 将元数据传递给下游节点
+
+节点通过 `attach_to({pre_nodes})` 连接，形成流式传输帧和元数据的流水线。
+
+### 节点分类
+
+| 类别 | 位置 | 示例 |
+|----------|----------|----------|
+| **源节点** | `vp_node/nodes/` | `vp_file_src_node`, `vp_rk_rtsp_src_node`, `vp_ffmpeg_src_node` |
+| **推理节点** | `vp_node/nodes/infer/` | `vp_rk_first_yolo`, `vp_rk_second_cls`, `vp_rk_second_rtmpose` |
+| **跟踪节点** | `vp_node/nodes/track/` | `vp_sort_track_node`, `vp_byte_track_node` |
+| **OSD节点** | `vp_node/nodes/osd/` | `vp_osd_node`, `vp_pose_osd_node` |
+| **目标节点** | `vp_node/nodes/base/` | `vp_screen_des_node`, `vp_rtmp_des_node`, `vp_file_des_node` |
+| **消息代理节点** | `vp_node/nodes/broker/` | `vp_json_console_broker_node` |
+
+### 推理节点模式
+
+推理节点继承自 `vp_infer_node` (vp_node/nodes/infer/vp_infer_node.h:19) 并实现 4 步流程：
+1. **prepare()**: 从帧元数据中提取裁剪区域/图像
+2. **preprocess()**: 归一化、缩放、均值/标准差减法（提供默认实现）
+3. **infer()**: 运行 RKNN 模型（提供默认实现）
+4. **postprocess()**: 解析输出并用结果更新帧元数据
+
+### 初级推理 vs 二级推理
+
+- **PRIMARY** (`vp_primary_infer_node`): 对整帧进行推理（如 YOLO 检测器）
+- **SECONDARY** (`vp_secondary_infer_node`): 对初级检测结果裁剪的区域进行推理（如对检测到的物体进行分类）
+
+二级节点通过 vector 参数按 `class_id` 过滤目标（参见 `main.cc:48-49`）。
+
+### 硬件加速组件
+
+| 组件 | 位置 | 用途 |
+|-----------|----------|---------|
+| **MPP** | `videocodec/mpp_decoder.cpp`, `mpp_encoder.cpp` | 硬件 H.264/H.265 编解码 |
+| **RGA** | `3rdparty/librga/` | 2D 图形操作（缩放、格式转换） |
+| **RKNN** | `models/rkbase.cpp` | NPU 神经网络推理 |
+
+## 模型配置
+
+模型通过 `assets/configs/` 中的 JSON 文件配置。每个模型配置指定：
+- RKNN 模型路径
+- 输入/输出维度
+- 标签文件
+- 预处理参数（mean, std, scale）
+
+`models/` 目录包含以下内容的 C++ 封装：
+- `yolo.cpp/h`: YOLO v5-v8 目标检测
+- `rtmpose.cpp/h`: 姿态估计
+- `classifier.cpp/h`: 图像分类
+
+## 重要文件
+
+- `main.cc`: 演示流水线定义 - 修改此文件可改变流水线结构
+- `cmake/common.cmake`: OpenCV 和 FFmpeg 库路径 - 如果库在非标准位置需要更新
+- `build-linux.sh`: 构建脚本
+- `vp_node/vp_utils/analysis_board/`: 流水线可视化工具
+
+## 开发说明
+
+### 添加新的节点类型
+
+1. 继承适当的基类（`vp_node`, `vp_infer_node`, `vp_src_node`, `vp_des_node`）
+2. 实现 `handle_frame_meta()` 进行逐帧处理
+3. 对于推理节点：实现 `prepare()` 和 `postprocess()`
+4. 在 `vp_node/CMakeLists.txt` 中注册（如需要）
+
+### 帧元数据流
+
+帧元数据（`vp_frame_meta`）携带：
+- 原始帧 (cv::Mat)
+- 检测到的目标 (`vp_frame_target`)
+- 跟踪、姿态、子目标
+- 用于录制/流传输的控制元数据
+
+元数据通过 `meta_flow()` 在流水线中传递，并累积来自每个节点的信息。
+
+### 线程模型
+
+每个节点运行两个线程：
+- **handle_thread**: 从 `in_queue` 处理传入的元数据
+- **dispatch_thread**: 将处理后的元数据推送到 `out_queue` 和下游节点
+
+同步使用信号量（`vp_semaphore`）和互斥锁。
+
+### 跨平台注意事项
+
+这是一个针对 RK3588 的 **aarch64** 构建。代码使用：
+- 瑞芯微特定库（MPP, RGA, RKNN runtime）
+- 带有 rkmpp 插件的 GStreamer 用于视频处理
+- 集成 MPP 的 FFmpeg
+- 支持 FreeType 的 OpenCV 4.6+
+
+## 测试
+
+没有统一的测试套件。使用：
+- `tests/main_model.cc`: 模型测试
+- `tests/main_track.cc`: 跟踪测试
+- `python/test_model.py`: Python 推理冒烟测试
+- `python/test_count.py`: Python 计数/跟踪测试
+
+验证时，使用 `assets/videos/` 中的示例视频运行完整流水线，并验证 OSD 输出或 RTMP 流。

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2,7 +2,10 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project(rk_videopipe)
 
-set(CMAKE_BUILD_TYPE "Debug")
+# 默认使用 Release，允许通过 -DCMAKE_BUILD_TYPE 覆盖。
+if (NOT CMAKE_BUILD_TYPE)
+    set(CMAKE_BUILD_TYPE "Release")
+endif ()
 set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 set(LIB_ARCH aarch64)

--- a/README.md
+++ b/README.md
@@ -100,6 +100,34 @@ cd RK_VideoPipe
 build/bin/rk_videopipe
 ```
 
+### 本地 MP4 文件显示示例
+
+按以下步骤可快速跑通“读取本地 mp4 并显示”：
+
+1. 准备测试视频（仓库已自带示例）：
+```
+assets/videos/person.mp4
+```
+2. 确认 `main.cc` 使用文件源节点，且路径指向本地 mp4：
+```cpp
+auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>(
+      "file_src_0", 0, "assets/videos/person.mp4", 1.0, true, "mppvideodec");
+```
+3. 构建并运行：
+```bash
+./build-linux.sh
+build/rk_videopipe
+```
+4. 程序启动后会弹出显示窗口（`vp_screen_des_node`），可看到检测/跟踪/关键点叠加结果。
+
+如需替换为你自己的视频，只需把 `main.cc` 中第三个参数改为你的 mp4 路径（例如 `"/data/test/demo.mp4"`），重新编译后运行即可。
+
+若无法显示，优先检查：
+```bash
+gst-launch-1.0 --version
+ls -l assets/videos/person.mp4
+```
+
 ### 参考项目
 
 [VideoPipe](https://github.com/sherlockchou86/VideoPipe.git): 主要参考项目，大部分节点定义和实现均由该仓库提供 \

--- a/assets/configs/yolo26.json
+++ b/assets/configs/yolo26.json
@@ -1,0 +1,10 @@
+{
+    "model_path": "/mnt/nfs/weights/rk3588/yolo26n_352_2c_2.rknn",
+    "labels": ["bird", "uav"],
+    "alarm_labels": ["bird", "uav"],
+    "model_type": "YOLO26",
+    "input_width": 640,
+    "input_height": 352,
+    "conf_threshold": 0.5,
+    "nms_threshold": 0.45
+}

--- a/main.cc
+++ b/main.cc
@@ -1,78 +1,102 @@
+/*
+ * RK_VideoPipe 主程序（MPP 解码直达 SDL 显示）
+ */
+
+#include <chrono>
 #include <iostream>
-#include <filesystem>
-
-#include "nodes/vp_ffmpeg_src_node.h"
-#include "nodes/vp_file_src_node.h"
-#include "nodes/vp_rk_rtsp_src_node.h"
-
-#include "nodes/infer/vp_rk_first_yolo.h"
-#include "nodes/infer/vp_rk_second_yolo.h"
-#include "nodes/infer/vp_rk_second_cls.h"
-#include "nodes/infer/vp_rk_second_rtmpose.h"
+#include <string>
+#include <thread>
 
 #include "nodes/vp_fake_des_node.h"
-#include "nodes/vp_rtmp_des_node.h"
-#include "nodes/vp_file_des_node.h"
-#include "nodes/vp_screen_des_node.h"
+#include "nodes/vp_mpp_sdl_src_node.h"
 
-#include "nodes/track/vp_sort_track_node.h"
-#include "nodes/track/vp_byte_track_node.h"
-#include "nodes/broker/vp_json_console_broker_node.h"
+/**
+ * @brief 解析可选命令行参数。
+ *
+ * 参数约定：
+ * 1) argv[1]: 输入视频路径（可选）
+ * 2) argv[2]: SDL 视频驱动（可选，如 x11/wayland/kmsdrm）
+ * 3) argv[3]: SDL 渲染驱动（可选，如 opengl/opengles2）
+ *
+ * @param argc 参数个数。
+ * @param argv 参数数组。
+ * @param file_path 输出视频路径。
+ * @param sdl_video_driver 输出 SDL 视频驱动。
+ * @param sdl_render_driver 输出 SDL 渲染驱动。
+ * @param render_to_screen 输出是否渲染到屏幕。
+ */
+static void parse_args(int argc,
+                       char** argv,
+                       std::string& file_path,
+                       std::string& sdl_video_driver,
+                       std::string& sdl_render_driver,
+                       bool& render_to_screen) {
+    if (argc > 1 && argv[1] != nullptr) {
+        file_path = argv[1];
+    }
+    if (argc > 2 && argv[2] != nullptr) {
+        sdl_video_driver = argv[2];
+    }
+    if (argc > 3 && argv[3] != nullptr) {
+        sdl_render_driver = argv[3];
+    }
+    if (argc > 4 && argv[4] != nullptr) {
+        const std::string render_arg = argv[4];
+        if (render_arg == "0" || render_arg == "false" || render_arg == "off") {
+            render_to_screen = false;
+        } else if (render_arg == "1" || render_arg == "true" || render_arg == "on") {
+            render_to_screen = true;
+        }
+    }
+}
 
-#include "nodes/osd/vp_osd_node.h"
-#include "nodes/osd/vp_pose_osd_node.h"
-#include "vp_utils/analysis_board/vp_analysis_board.h"
-
-/*-------------------------------------------
-                  Main Functions
--------------------------------------------*/
-int main(int argc, char** argv)
-{
-    //std::filesystem::current_path("/root/.vs/RK_VideoPipe/41b606b4-6586-4527-af89-a26a0ab1539d/src");
+int main(int argc, char** argv) {
     VP_SET_LOG_INCLUDE_CODE_LOCATION(false);
     VP_SET_LOG_INCLUDE_THREAD_ID(false);
     VP_SET_LOG_LEVEL(vp_utils::INFO);
     VP_LOGGER_INIT();
 
-    // create nodes
-    auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>("file_src_0", 0, "/mnt/nfs/datasets/video/uav.mp4", 1.0, true, "mppvideodec");
-    // auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>("rtsp_src_0", 0, "assets/videos/person.mp4", 1.0, true, "mppvideodec");
-    // auto src_0 = std::make_shared<vp_nodes::vp_rk_rtsp_src_node>("rtsp_src_0", 0, "rtsp://admin:hk123456@192.168.3.26:554/Streaming/Channels/301");
-    // auto src_0 = std::make_shared<vp_nodes::vp_ffmpeg_src_node>("rtsp_src_0", 0, "rtsp://admin:hk123456@192.168.3.26:554/Streaming/Channels/301");
+    // 默认输入视频路径。
+    std::string file_path = "/mnt/nfs/datasets/video/uav.mp4";
+    // SDL 视频驱动（默认自动选择）。
+    std::string sdl_video_driver = "";
+    // SDL 渲染驱动（默认自动选择）。
+    std::string sdl_render_driver = "";
+    // 是否渲染到屏幕（默认开启）。
+    bool render_to_screen = true;
+    parse_args(argc, argv, file_path, sdl_video_driver, sdl_render_driver, render_to_screen);
 
-    auto yolo_0 = std::make_shared<vp_nodes::vp_rk_first_yolo>("rk_yolo_0", "assets/configs/person.json");
-    //auto track_0 = std::make_shared<vp_nodes::vp_sort_track_node>("track_0");
-    auto track_0 = std::make_shared<vp_nodes::vp_byte_track_node>("track_0");
+    VP_INFO(vp_utils::string_format("[main] file=%s sdl_video_driver=%s sdl_render_driver=%s render=%d",
+                                    file_path.c_str(),
+                                    sdl_video_driver.empty() ? "auto" : sdl_video_driver.c_str(),
+                                    sdl_render_driver.empty() ? "auto" : sdl_render_driver.c_str(),
+                                    render_to_screen ? 1 : 0));
 
-    //auto yolo_sub_0 = std::make_shared<vp_nodes::vp_rk_second_yolo>("rk_yolo_sub_0", "assets/configs/phone.json");
-    auto pose_0 = std::make_shared<vp_nodes::vp_rk_second_rtmpose>("rk_rtmpose_0", "assets/configs/rtmpose.json", std::vector<int>{0});
-    auto cls_0 = std::make_shared<vp_nodes::vp_rk_second_cls>("rk_cls_0", "assets/configs/stand_sit.json", std::vector<int>{0});
+    // MPP+SDL 源节点（吞吐优先）。
+    auto src_0 = std::make_shared<vp_nodes::vp_mpp_sdl_src_node>(
+        "file_src_0",
+        0,
+        file_path,
+        true,               // 循环播放。
+        false,              // 不按源 FPS 节奏限速。
+        false,              // 关闭 vsync。
+        true,               // 关闭 overlay。
+        false,              // 不启用全屏，保持与 mp4_hw_dec_sdl2 默认一致。
+        render_to_screen,   // 是否开启屏幕渲染。
+        false,              // 不向下游发布 frame_meta。
+        sdl_video_driver,   // SDL 视频驱动。
+        sdl_render_driver   // SDL 渲染驱动。
+    );
 
-    auto osd_0 = std::make_shared<vp_nodes::vp_osd_node>("osd_0");
-    auto pose_osd_0 = std::make_shared<vp_nodes::vp_pose_osd_node>("pose_osd_0");
-
-    //auto des_0 = std::make_shared<vp_nodes::vp_rtmp_des_node>("rtmp_des_0", 0, "rtmp://192.168.3.100:1935/stream");
-    //auto des_0 = std::make_shared<vp_nodes::vp_fake_des_node>("fake_des_0", 0);
-    //auto des_0 = std::make_shared<vp_nodes::vp_file_des_node>("file_des_0", 0, "out");
-    auto des_0 = std::make_shared<vp_nodes::vp_screen_des_node>("screen_des_0", 0);
-
-    auto msg_broker = std::make_shared<vp_nodes::vp_json_console_broker_node>("broker_0");
-
-    yolo_0->attach_to({ src_0 });
-    track_0->attach_to({ yolo_0 });
-    cls_0->attach_to({ track_0 });
-    pose_0->attach_to({ cls_0 });
-    osd_0->attach_to({ pose_0 });
-    pose_osd_0->attach_to({ osd_0 });
-    msg_broker->attach_to({ pose_osd_0 });
-    des_0->attach_to({ msg_broker });
+    // 占位目标节点（满足 pipeline 以 DES 结束）。
+    auto des_0 = std::make_shared<vp_nodes::vp_fake_des_node>("fake_des_0", 0);
+    des_0->attach_to({src_0});
 
     src_0->start();
 
-    //getchar();
-    //src_0->detach_recursively();
-    vp_utils::vp_analysis_board board({ src_0 });
-    board.display();
+    while (true) {
+        std::this_thread::sleep_for(std::chrono::seconds(1));
+    }
 
     return 0;
 }

--- a/main.cc
+++ b/main.cc
@@ -26,7 +26,7 @@
 /*-------------------------------------------
                   Main Functions
 -------------------------------------------*/
-int main(int argc, char** argv) 
+int main(int argc, char** argv)
 {
     //std::filesystem::current_path("/root/.vs/RK_VideoPipe/41b606b4-6586-4527-af89-a26a0ab1539d/src");
     VP_SET_LOG_INCLUDE_CODE_LOCATION(false);
@@ -35,19 +35,20 @@ int main(int argc, char** argv)
     VP_LOGGER_INIT();
 
     // create nodes
-    auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>("rtsp_src_0", 0, "assets/videos/person.mp4", 1.0, true, "mppvideodec");
+    auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>("file_src_0", 0, "/mnt/nfs/datasets/video/uav.mp4", 1.0, true, "mppvideodec");
+    // auto src_0 = std::make_shared<vp_nodes::vp_file_src_node>("rtsp_src_0", 0, "assets/videos/person.mp4", 1.0, true, "mppvideodec");
     // auto src_0 = std::make_shared<vp_nodes::vp_rk_rtsp_src_node>("rtsp_src_0", 0, "rtsp://admin:hk123456@192.168.3.26:554/Streaming/Channels/301");
     // auto src_0 = std::make_shared<vp_nodes::vp_ffmpeg_src_node>("rtsp_src_0", 0, "rtsp://admin:hk123456@192.168.3.26:554/Streaming/Channels/301");
 
-    auto yolo_0  = std::make_shared<vp_nodes::vp_rk_first_yolo>("rk_yolo_0", "assets/configs/person.json");    
+    auto yolo_0 = std::make_shared<vp_nodes::vp_rk_first_yolo>("rk_yolo_0", "assets/configs/person.json");
     //auto track_0 = std::make_shared<vp_nodes::vp_sort_track_node>("track_0");
     auto track_0 = std::make_shared<vp_nodes::vp_byte_track_node>("track_0");
 
     //auto yolo_sub_0 = std::make_shared<vp_nodes::vp_rk_second_yolo>("rk_yolo_sub_0", "assets/configs/phone.json");
     auto pose_0 = std::make_shared<vp_nodes::vp_rk_second_rtmpose>("rk_rtmpose_0", "assets/configs/rtmpose.json", std::vector<int>{0});
-    auto cls_0  = std::make_shared<vp_nodes::vp_rk_second_cls>("rk_cls_0", "assets/configs/stand_sit.json", std::vector<int>{0});
-    
-    auto osd_0      = std::make_shared<vp_nodes::vp_osd_node>("osd_0");
+    auto cls_0 = std::make_shared<vp_nodes::vp_rk_second_cls>("rk_cls_0", "assets/configs/stand_sit.json", std::vector<int>{0});
+
+    auto osd_0 = std::make_shared<vp_nodes::vp_osd_node>("osd_0");
     auto pose_osd_0 = std::make_shared<vp_nodes::vp_pose_osd_node>("pose_osd_0");
 
     //auto des_0 = std::make_shared<vp_nodes::vp_rtmp_des_node>("rtmp_des_0", 0, "rtmp://192.168.3.100:1935/stream");
@@ -57,20 +58,20 @@ int main(int argc, char** argv)
 
     auto msg_broker = std::make_shared<vp_nodes::vp_json_console_broker_node>("broker_0");
 
-    yolo_0->attach_to({src_0});
-    track_0->attach_to({yolo_0});
-    cls_0->attach_to({track_0});
-    pose_0->attach_to({cls_0});
-    osd_0->attach_to({pose_0});
-    pose_osd_0->attach_to({osd_0});
-    msg_broker->attach_to({pose_osd_0});
-    des_0->attach_to({msg_broker});
+    yolo_0->attach_to({ src_0 });
+    track_0->attach_to({ yolo_0 });
+    cls_0->attach_to({ track_0 });
+    pose_0->attach_to({ cls_0 });
+    osd_0->attach_to({ pose_0 });
+    pose_osd_0->attach_to({ osd_0 });
+    msg_broker->attach_to({ pose_osd_0 });
+    des_0->attach_to({ msg_broker });
 
     src_0->start();
 
     //getchar();
     //src_0->detach_recursively();
-    vp_utils::vp_analysis_board board({src_0});
+    vp_utils::vp_analysis_board board({ src_0 });
     board.display();
 
     return 0;

--- a/main.cc
+++ b/main.cc
@@ -1,20 +1,105 @@
 /*
- * RK_VideoPipe 主程序（MPP 解码直达 SDL 显示）
+ * RK_VideoPipe 主程序（MPP 解码 + YOLO26 推理 + OSD 显示）
  */
 
 #include <chrono>
 #include <csignal>
 #include <atomic>
 #include <iostream>
+#include <termios.h>
 #include <string>
 #include <thread>
+#include <unistd.h>
+#include <sys/select.h>
 
-#include "nodes/vp_fake_des_node.h"
+#include "nodes/infer/vp_rk_first_yolo26.h"
+#include "nodes/osd/vp_osd_node.h"
 #include "nodes/vp_mpp_sdl_src_node.h"
+#include "nodes/vp_screen_des_node.h"
 #include "vp_utils/analysis_board/vp_analysis_board.h"
 
 // 进程退出标志。
 static std::atomic<bool> g_should_exit{false};
+
+/**
+ * @brief 终端原始模式守卫（用于捕获 ESC 无需回车）。
+ */
+class TerminalRawModeGuard {
+public:
+    /**
+     * @brief 构造并尝试切换终端到非规范模式。
+     */
+    TerminalRawModeGuard() {
+        // 记录标准输入是否为 TTY。
+        const bool is_tty = (isatty(STDIN_FILENO) == 1);
+        if (!is_tty) {
+            return;
+        }
+
+        // 旧终端配置读取结果。
+        const int get_ret = tcgetattr(STDIN_FILENO, &old_termios_);
+        if (get_ret != 0) {
+            return;
+        }
+
+        // 新终端配置（基于旧配置拷贝）。
+        struct termios new_termios = old_termios_;
+        new_termios.c_lflag &= static_cast<unsigned int>(~(ICANON | ECHO));
+        new_termios.c_cc[VMIN] = 0;
+        new_termios.c_cc[VTIME] = 0;
+
+        // 切换终端配置结果。
+        const int set_ret = tcsetattr(STDIN_FILENO, TCSANOW, &new_termios);
+        if (set_ret == 0) {
+            enabled_ = true;
+        }
+    }
+
+    /**
+     * @brief 析构时恢复终端配置。
+     */
+    ~TerminalRawModeGuard() {
+        if (enabled_) {
+            tcsetattr(STDIN_FILENO, TCSANOW, &old_termios_);
+        }
+    }
+
+private:
+    // 原终端配置。
+    struct termios old_termios_ {};
+    // 是否已成功启用原始模式。
+    bool enabled_ = false;
+};
+
+/**
+ * @brief 非阻塞检测终端是否按下 ESC。
+ * @return true 按下 ESC；false 未按下。
+ */
+static bool check_terminal_escape_pressed() {
+    // 读集合。
+    fd_set read_fds;
+    FD_ZERO(&read_fds);
+    FD_SET(STDIN_FILENO, &read_fds);
+
+    // 超时配置（立即返回）。
+    struct timeval timeout {};
+    timeout.tv_sec = 0;
+    timeout.tv_usec = 0;
+
+    // select 结果。
+    const int ready = select(STDIN_FILENO + 1, &read_fds, nullptr, nullptr, &timeout);
+    if (ready <= 0 || !FD_ISSET(STDIN_FILENO, &read_fds)) {
+        return false;
+    }
+
+    // 读取到的字符。
+    unsigned char ch = 0;
+    const ssize_t read_size = read(STDIN_FILENO, &ch, 1);
+    if (read_size == 1 && ch == 27U) {
+        return true;
+    }
+    return false;
+}
 
 /**
  * @brief 处理退出信号，仅设置退出标志位。
@@ -33,20 +118,24 @@ static void handle_exit_signal(int signal_number) {
  * 1) argv[1]: 输入视频路径（可选）
  * 2) argv[2]: SDL 视频驱动（可选，如 x11/wayland/kmsdrm）
  * 3) argv[3]: SDL 渲染驱动（可选，如 opengl/opengles2）
+ * 4) argv[4]: YOLO26 配置路径（可选）
+ * 5) argv[5]: 屏幕 sink（可选，如 ximagesink/waylandsink/kmssink）
  *
  * @param argc 参数个数。
  * @param argv 参数数组。
  * @param file_path 输出视频路径。
  * @param sdl_video_driver 输出 SDL 视频驱动。
  * @param sdl_render_driver 输出 SDL 渲染驱动。
- * @param render_to_screen 输出是否渲染到屏幕。
+ * @param yolo26_config_path 输出 YOLO26 配置路径。
+ * @param screen_sink 输出屏幕 sink 名称。
  */
 static void parse_args(int argc,
                        char** argv,
                        std::string& file_path,
                        std::string& sdl_video_driver,
                        std::string& sdl_render_driver,
-                       bool& render_to_screen) {
+                       std::string& yolo26_config_path,
+                       std::string& screen_sink) {
     if (argc > 1 && argv[1] != nullptr) {
         file_path = argv[1];
     }
@@ -57,12 +146,10 @@ static void parse_args(int argc,
         sdl_render_driver = argv[3];
     }
     if (argc > 4 && argv[4] != nullptr) {
-        const std::string render_arg = argv[4];
-        if (render_arg == "0" || render_arg == "false" || render_arg == "off") {
-            render_to_screen = false;
-        } else if (render_arg == "1" || render_arg == "true" || render_arg == "on") {
-            render_to_screen = true;
-        }
+        yolo26_config_path = argv[4];
+    }
+    if (argc > 5 && argv[5] != nullptr) {
+        screen_sink = argv[5];
     }
 }
 
@@ -75,6 +162,10 @@ int main(int argc, char** argv) {
     VP_SET_LOG_INCLUDE_THREAD_ID(false);
     VP_SET_LOG_LEVEL(vp_utils::INFO);
     VP_LOGGER_INIT();
+    // 终端 ESC 监听守卫（自动恢复终端配置）。
+    TerminalRawModeGuard terminal_raw_mode_guard;
+    // 重置屏幕窗口退出请求标志。
+    vp_nodes::vp_screen_des_reset_exit_flag();
 
     // 默认输入视频路径。
     std::string file_path = "/mnt/nfs/datasets/video/uav.mp4";
@@ -82,17 +173,20 @@ int main(int argc, char** argv) {
     std::string sdl_video_driver = "";
     // SDL 渲染驱动（默认自动选择）。
     std::string sdl_render_driver = "";
-    // 是否渲染到屏幕（默认开启，可通过第4参数关闭）。
-    bool render_to_screen = true;
-    parse_args(argc, argv, file_path, sdl_video_driver, sdl_render_driver, render_to_screen);
+    // YOLO26 配置路径。
+    std::string yolo26_config_path = "assets/configs/yolo26.json";
+    // 屏幕显示 sink。
+    std::string screen_sink = "autovideosink";
+    parse_args(argc, argv, file_path, sdl_video_driver, sdl_render_driver, yolo26_config_path, screen_sink);
 
-    VP_INFO(vp_utils::string_format("[main] file=%s sdl_video_driver=%s sdl_render_driver=%s render=%d",
+    VP_INFO(vp_utils::string_format("[main] file=%s sdl_video_driver=%s sdl_render_driver=%s yolo26_cfg=%s sink=%s",
                                     file_path.c_str(),
                                     sdl_video_driver.empty() ? "auto" : sdl_video_driver.c_str(),
                                     sdl_render_driver.empty() ? "auto" : sdl_render_driver.c_str(),
-                                    render_to_screen ? 1 : 0));
+                                    yolo26_config_path.c_str(),
+                                    screen_sink.c_str()));
 
-    // MPP+SDL 源节点（吞吐优先）。
+    // MPP 源节点（开启 frame_meta 发布给推理节点，关闭源直渲染）。
     auto src_0 = std::make_shared<vp_nodes::vp_mpp_sdl_src_node>(
         "file_src_0",
         0,
@@ -102,15 +196,21 @@ int main(int argc, char** argv) {
         false,              // 关闭 vsync。
         true,               // 关闭 overlay。
         false,              // 不启用全屏，保持与 mp4_hw_dec_sdl2 默认一致。
-        render_to_screen,   // 是否开启屏幕渲染。
-        false,              // 不发布 frame_meta，避免 NV12 转 BGR。
+        false,              // 关闭源节点直渲染，统一由 screen_des 显示。
+        true,               // 发布 frame_meta 给后续推理/OSD。
         sdl_video_driver,   // SDL 视频驱动。
         sdl_render_driver   // SDL 渲染驱动。
     );
 
-    // 占位目标节点（仅显示，不做下游编码）。
-    auto des_0 = std::make_shared<vp_nodes::vp_fake_des_node>("fake_des_0", 0);
-    des_0->attach_to({src_0});
+    // YOLO26 检测节点。
+    auto yolo26_0 = std::make_shared<vp_nodes::vp_rk_first_yolo26>("yolo26_0", yolo26_config_path);
+    // OSD 节点。
+    auto osd_0 = std::make_shared<vp_nodes::vp_osd_node>("osd_0");
+    // 屏幕显示节点。
+    auto screen_des_0 = std::make_shared<vp_nodes::vp_screen_des_node>("screen_des_0", 0, true, vp_objects::vp_size(), false, screen_sink);
+    yolo26_0->attach_to({src_0});
+    osd_0->attach_to({yolo26_0});
+    screen_des_0->attach_to({osd_0});
 
     src_0->start();
 
@@ -119,6 +219,16 @@ int main(int argc, char** argv) {
     board.display(1, false);
 
     while (!g_should_exit.load()) {
+        if (vp_nodes::vp_screen_des_should_exit()) {
+            VP_INFO("[main] window exit requested, exiting...");
+            g_should_exit.store(true);
+            break;
+        }
+        if (check_terminal_escape_pressed()) {
+            VP_INFO("[main] ESC detected from terminal, exiting...");
+            g_should_exit.store(true);
+            break;
+        }
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
 

--- a/models/config.h
+++ b/models/config.h
@@ -2,7 +2,7 @@
 #include <vector>
 #include <string>
 
-enum class ModelType{YOLOv5, YOLOv6, YOLOv7, YOLOv8, ResNet18, MobileNetv3, RTMPose};
+enum class ModelType{YOLOv5, YOLOv6, YOLOv7, YOLOv8, YOLO26, ResNet18, MobileNetv3, RTMPose};
 
 struct Config{
     std::string model_path;
@@ -15,6 +15,14 @@ struct YOLOConfig: public Config{
     ModelType type = ModelType::YOLOv5;
     float conf_threshold = 0.25;
     float nms_threshold = 0.45;
+};
+
+struct YOLO26Config: public Config{
+    ModelType type = ModelType::YOLO26;
+    float conf_threshold = 0.5;
+    float nms_threshold = 0.45;
+    int input_width = 640;
+    int input_height = 352;
 };
 
 struct ClsConfig: public Config{

--- a/models/yolo26.cpp
+++ b/models/yolo26.cpp
@@ -1,0 +1,207 @@
+#include "yolo26.h"
+
+#include <algorithm>
+#include <cstring>
+#include <fstream>
+#include <map>
+#include <utility>
+
+#include <opencv2/imgproc.hpp>
+
+YOLO26::YOLO26(const YOLO26Config& config) : RKBASE(config.model_path), config(config) {
+    // 使用模型真实输入尺寸，避免配置尺寸与模型不一致导致越界访问。
+    this->config.input_width = model_width;
+    this->config.input_height = model_height;
+    this->postprocessor = std::make_unique<Yolo26PostProcessor>(this->config);
+}
+
+YOLO26::~YOLO26() = default;
+
+int YOLO26::load_config(const std::string& json_path, YOLO26Config& conf) {
+    std::ifstream stream(json_path);  // 配置文件输入流。
+    if (!stream.is_open()) {
+        return -1;
+    }
+
+    json j_conf;  // JSON 配置对象。
+    stream >> j_conf;
+
+    conf.model_path = j_conf.value("model_path", "");
+    conf.conf_threshold = j_conf.value("conf_threshold", 0.5f);
+    conf.nms_threshold = j_conf.value("nms_threshold", 0.45f);
+    conf.input_width = j_conf.value("input_width", 640);
+    conf.input_height = j_conf.value("input_height", 352);
+    conf.core_mask = j_conf.value("core_mask", 0);
+    conf.type = ModelType::YOLO26;
+
+    conf.labels.clear();
+    if (j_conf.contains("labels") && j_conf["labels"].is_array()) {
+        for (const auto& item : j_conf["labels"]) {
+            conf.labels.push_back(item.template get<std::string>());
+        }
+    }
+    if (conf.labels.empty()) {
+        conf.labels = {"bird", "uav"};
+    }
+
+    conf.alarm_labels.clear();
+    if (j_conf.contains("alarm_labels") && j_conf["alarm_labels"].is_array()) {
+        for (const auto& item : j_conf["alarm_labels"]) {
+            conf.alarm_labels.push_back(item.template get<std::string>());
+        }
+    }
+    if (conf.alarm_labels.empty()) {
+        conf.alarm_labels = conf.labels;
+    }
+
+    if (conf.model_path.empty() || conf.input_width <= 0 || conf.input_height <= 0) {
+        return -2;
+    }
+    return 0;
+}
+
+bool YOLO26::output_to_chw(const rknn_output& output, const rknn_tensor_attr& attr, Yolo26HeadTensor& tensor) {
+    if (output.buf == nullptr) {
+        return false;
+    }
+    const float* src = reinterpret_cast<const float*>(output.buf);  // 输出浮点缓冲区。
+    if (src == nullptr) {
+        return false;
+    }
+
+    if (attr.n_dims == 4) {
+        if (attr.fmt == RKNN_TENSOR_NCHW) {
+            tensor.num_cls = attr.dims[1];
+            tensor.feat_h = attr.dims[2];
+            tensor.feat_w = attr.dims[3];
+            const size_t total = static_cast<size_t>(tensor.num_cls) * tensor.feat_h * tensor.feat_w;  // 总元素数。
+            tensor.cls.assign(src, src + total);
+            return true;
+        }
+
+        tensor.feat_h = attr.dims[1];
+        tensor.feat_w = attr.dims[2];
+        tensor.num_cls = attr.dims[3];
+        const size_t total = static_cast<size_t>(tensor.num_cls) * tensor.feat_h * tensor.feat_w;  // 总元素数。
+        tensor.cls.resize(total);
+        for (int y = 0; y < tensor.feat_h; ++y) {
+            for (int x = 0; x < tensor.feat_w; ++x) {
+                for (int c = 0; c < tensor.num_cls; ++c) {
+                    const size_t nhwci = static_cast<size_t>(y) * tensor.feat_w * tensor.num_cls + static_cast<size_t>(x) * tensor.num_cls + c;  // NHWC 索引。
+                    const size_t chwi = static_cast<size_t>(c) * tensor.feat_h * tensor.feat_w + static_cast<size_t>(y) * tensor.feat_w + x;  // CHW 索引。
+                    tensor.cls[chwi] = src[nhwci];
+                }
+            }
+        }
+        return true;
+    }
+
+    if (attr.n_dims == 3) {
+        tensor.num_cls = attr.dims[0];
+        tensor.feat_h = attr.dims[1];
+        tensor.feat_w = attr.dims[2];
+        const size_t total = static_cast<size_t>(tensor.num_cls) * tensor.feat_h * tensor.feat_w;  // 总元素数。
+        tensor.cls.assign(src, src + total);
+        return true;
+    }
+
+    return false;
+}
+
+void YOLO26::run(const cv::Mat& src, std::vector<DetectionResult>& res) {
+    res.clear();
+    if (src.empty()) {
+        return;
+    }
+
+    const int orig_w = src.cols;  // 原图宽度。
+    const int orig_h = src.rows;  // 原图高度。
+    const float ratio_w = static_cast<float>(config.input_width) / static_cast<float>(orig_w);  // 宽方向缩放比。
+    const float ratio_h = static_cast<float>(config.input_height) / static_cast<float>(orig_h);  // 高方向缩放比。
+
+    cv::Mat rgb_img;  // RGB 图像。
+    cv::cvtColor(src, rgb_img, cv::COLOR_BGR2RGB);
+    cv::Mat resized_rgb;  // 缩放后的 RGB 图像。
+    cv::resize(rgb_img, resized_rgb, cv::Size(config.input_width, config.input_height), 0, 0, cv::INTER_LINEAR);
+
+    inputs[0].buf = resized_rgb.data;
+    ret = rknn_inputs_set(ctx, io_num.n_input, inputs);
+    if (ret < 0) {
+        return;
+    }
+
+    std::vector<rknn_output> outputs(io_num.n_output);  // RKNN 输出容器。
+    for (uint32_t i = 0; i < io_num.n_output; ++i) {
+        outputs[i].index = i;
+        outputs[i].want_float = 1;
+        outputs[i].is_prealloc = 0;
+    }
+
+    ret = rknn_run(ctx, nullptr);
+    if (ret < 0) {
+        return;
+    }
+    ret = rknn_outputs_get(ctx, io_num.n_output, outputs.data(), nullptr);
+    if (ret < 0) {
+        return;
+    }
+
+    struct PartialHead {
+        int feat_h = 0;  // 特征图高度。
+        int feat_w = 0;  // 特征图宽度。
+        int cls_c = 0;  // 分类通道数。
+        std::vector<float> reg;  // 回归数据。
+        std::vector<float> cls;  // 分类数据。
+    };
+
+    std::map<std::pair<int, int>, PartialHead> head_map;  // 以 (H,W) 聚合分支输出。
+    for (uint32_t i = 0; i < io_num.n_output; ++i) {
+        Yolo26HeadTensor tensor;  // 临时张量。
+        if (!output_to_chw(outputs[i], output_attrs[i], tensor)) {
+            continue;
+        }
+
+        auto key = std::make_pair(tensor.feat_h, tensor.feat_w);  // 当前 head 键。
+        auto& partial = head_map[key];
+        partial.feat_h = tensor.feat_h;
+        partial.feat_w = tensor.feat_w;
+        if (tensor.num_cls == 4) {
+            partial.reg = std::move(tensor.cls);
+        } else {
+            partial.cls = std::move(tensor.cls);
+            partial.cls_c = tensor.num_cls;
+        }
+    }
+
+    std::vector<Yolo26HeadTensor> heads;  // 最终 head 集合。
+    heads.reserve(head_map.size());
+    for (auto& pair : head_map) {
+        auto& partial = pair.second;
+        if (partial.reg.empty() || partial.cls.empty() || partial.cls_c <= 0) {
+            continue;
+        }
+        Yolo26HeadTensor head;  // 待解码 head。
+        head.feat_h = partial.feat_h;
+        head.feat_w = partial.feat_w;
+        head.num_cls = partial.cls_c;
+        head.reg = std::move(partial.reg);
+        head.cls = std::move(partial.cls);
+        heads.push_back(std::move(head));
+    }
+    std::sort(heads.begin(), heads.end(), [](const Yolo26HeadTensor& a, const Yolo26HeadTensor& b) {
+        return a.feat_h > b.feat_h;
+    });
+
+    postprocessor->run(heads, orig_w, orig_h, ratio_w, ratio_h, res);
+    rknn_outputs_release(ctx, io_num.n_output, outputs.data());
+}
+
+void YOLO26::run(std::vector<cv::Mat>& img_datas, std::vector<std::vector<DetectionResult>>& res_datas) {
+    res_datas.clear();
+    for (auto& image : img_datas) {
+        std::vector<DetectionResult> single_res;  // 单帧结果。
+        run(image, single_res);
+        res_datas.push_back(single_res);
+    }
+}
+

--- a/models/yolo26.h
+++ b/models/yolo26.h
@@ -1,0 +1,64 @@
+#pragma once
+
+#include <memory>
+#include <string>
+#include <vector>
+
+#include <opencv2/core.hpp>
+
+#include "rkbase.h"
+#include "yolo26_post.h"
+
+/**
+ * @brief YOLO26 RKNN 推理模型封装。
+ */
+class YOLO26 : public RKBASE {
+public:
+    /**
+     * @brief 构造 YOLO26 模型。
+     * @param config YOLO26 配置。
+     */
+    explicit YOLO26(const YOLO26Config& config);
+
+    /**
+     * @brief 释放模型资源。
+     */
+    ~YOLO26();
+
+    /**
+     * @brief 加载 YOLO26 JSON 配置。
+     * @param json_path 配置文件路径。
+     * @param conf 输出配置。
+     * @return int 0 成功，非 0 失败。
+     */
+    static int load_config(const std::string& json_path, YOLO26Config& conf);
+
+    /**
+     * @brief 单帧推理。
+     * @param src 输入 BGR 图像。
+     * @param res 输出检测结果。
+     */
+    void run(const cv::Mat& src, std::vector<DetectionResult>& res);
+
+    /**
+     * @brief 多帧推理（顺序逐帧执行）。
+     * @param img_datas 输入图像列表。
+     * @param res_datas 输出结果列表。
+     */
+    void run(std::vector<cv::Mat>& img_datas, std::vector<std::vector<DetectionResult>>& res_datas);
+
+private:
+    /**
+     * @brief 把 RKNN 输出张量转换为 CHW 格式。
+     * @param output RKNN 输出。
+     * @param attr 张量属性。
+     * @param tensor 输出 head 张量。
+     * @return true 转换成功；false 转换失败。
+     */
+    static bool output_to_chw(const rknn_output& output, const rknn_tensor_attr& attr, Yolo26HeadTensor& tensor);
+
+private:
+    YOLO26Config config;  // YOLO26 运行配置。
+    std::unique_ptr<Yolo26PostProcessor> postprocessor;  // 后处理对象。
+};
+

--- a/models/yolo26_post.cpp
+++ b/models/yolo26_post.cpp
@@ -1,0 +1,145 @@
+#include "yolo26_post.h"
+
+#include <algorithm>
+#include <cmath>
+
+Yolo26PostProcessor::Yolo26PostProcessor(const YOLO26Config& config) : config(config) {}
+
+float Yolo26PostProcessor::sigmoid(float x) {
+    return 1.0f / (1.0f + std::exp(-x));
+}
+
+float Yolo26PostProcessor::box_iou(const Detection& a, const Detection& b) {
+    const float xx1 = std::max(a.x1, b.x1);  // 相交区域左上角 x。
+    const float yy1 = std::max(a.y1, b.y1);  // 相交区域左上角 y。
+    const float xx2 = std::min(a.x2, b.x2);  // 相交区域右下角 x。
+    const float yy2 = std::min(a.y2, b.y2);  // 相交区域右下角 y。
+
+    const float iw = std::max(0.0f, xx2 - xx1);  // 相交宽度。
+    const float ih = std::max(0.0f, yy2 - yy1);  // 相交高度。
+    const float inter = iw * ih;  // 相交面积。
+
+    const float area_a = std::max(0.0f, a.x2 - a.x1) * std::max(0.0f, a.y2 - a.y1);  // A 面积。
+    const float area_b = std::max(0.0f, b.x2 - b.x1) * std::max(0.0f, b.y2 - b.y1);  // B 面积。
+    const float uni = area_a + area_b - inter;  // 并集面积。
+    if (uni <= 0.0f) {
+        return 0.0f;
+    }
+    return inter / uni;
+}
+
+std::vector<Yolo26PostProcessor::Detection> Yolo26PostProcessor::nms_per_class(const std::vector<Detection>& boxes, float nms_thres) {
+    std::map<int, std::vector<Detection>> cls_buckets;  // 按类别分桶。
+    for (const auto& box : boxes) {
+        cls_buckets[box.cls_id].push_back(box);
+    }
+
+    std::vector<Detection> kept;  // 保留结果。
+    for (auto& pair : cls_buckets) {
+        auto& cls_boxes = pair.second;  // 当前类别检测框。
+        std::sort(cls_boxes.begin(), cls_boxes.end(), [](const Detection& a, const Detection& b) {
+            return a.score > b.score;
+        });
+
+        while (!cls_boxes.empty()) {
+            const Detection best = cls_boxes.front();  // 当前最高分框。
+            kept.push_back(best);
+            cls_boxes.erase(cls_boxes.begin());
+
+            std::vector<Detection> remain;  // NMS 后剩余框。
+            remain.reserve(cls_boxes.size());
+            for (const auto& box : cls_boxes) {
+                if (box_iou(best, box) < nms_thres) {
+                    remain.push_back(box);
+                }
+            }
+            cls_boxes.swap(remain);
+        }
+    }
+
+    return kept;
+}
+
+int Yolo26PostProcessor::run(const std::vector<Yolo26HeadTensor>& heads,
+                             int orig_w,
+                             int orig_h,
+                             float ratio_w,
+                             float ratio_h,
+                             std::vector<DetectionResult>& results) const {
+    std::vector<Detection> boxes;  // 解码后的候选框。
+    for (const auto& head : heads) {
+        if (head.feat_h <= 0 || head.feat_w <= 0 || head.num_cls <= 0) {
+            continue;
+        }
+        const int hw = head.feat_h * head.feat_w;  // 特征图像素总数。
+        if (head.reg.size() != static_cast<size_t>(4 * hw) || head.cls.size() != static_cast<size_t>(head.num_cls * hw)) {
+            continue;
+        }
+
+        const float stride_h = static_cast<float>(config.input_height) / static_cast<float>(head.feat_h);  // 高方向 stride。
+        const float stride_w = static_cast<float>(config.input_width) / static_cast<float>(head.feat_w);  // 宽方向 stride。
+        if (std::fabs(stride_h - stride_w) > 1e-6f) {
+            continue;
+        }
+        const float stride = stride_h;  // 当前分支 stride。
+
+        for (int h = 0; h < head.feat_h; ++h) {
+            for (int w = 0; w < head.feat_w; ++w) {
+                const int base_idx = h * head.feat_w + w;  // 当前栅格线性索引。
+                int best_cls = -1;  // 最佳类别 ID。
+                float best_score = -1.0f;  // 最佳类别分数。
+                for (int c = 0; c < head.num_cls; ++c) {
+                    const float score = sigmoid(head.cls[c * hw + base_idx]);
+                    if (score > best_score) {
+                        best_score = score;
+                        best_cls = c;
+                    }
+                }
+
+                if (best_cls < 0 || best_score < config.conf_threshold) {
+                    continue;
+                }
+
+                const float grid_x = static_cast<float>(w) + 0.5f;  // 栅格中心 x。
+                const float grid_y = static_cast<float>(h) + 0.5f;  // 栅格中心 y。
+                float x1 = (grid_x - head.reg[0 * hw + base_idx]) * stride;  // 输入尺度 x1。
+                float y1 = (grid_y - head.reg[1 * hw + base_idx]) * stride;  // 输入尺度 y1。
+                float x2 = (grid_x + head.reg[2 * hw + base_idx]) * stride;  // 输入尺度 x2。
+                float y2 = (grid_y + head.reg[3 * hw + base_idx]) * stride;  // 输入尺度 y2。
+
+                x1 /= ratio_w;
+                y1 /= ratio_h;
+                x2 /= ratio_w;
+                y2 /= ratio_h;
+
+                x1 = std::max(0.0f, std::min(static_cast<float>(orig_w), x1));
+                y1 = std::max(0.0f, std::min(static_cast<float>(orig_h), y1));
+                x2 = std::max(0.0f, std::min(static_cast<float>(orig_w), x2));
+                y2 = std::max(0.0f, std::min(static_cast<float>(orig_h), y2));
+                boxes.push_back({x1, y1, x2, y2, best_score, best_cls});
+            }
+        }
+    }
+
+    const std::vector<Detection> kept = nms_per_class(boxes, config.nms_threshold);  // NMS 后保留框。
+    results.clear();
+    results.reserve(kept.size());
+    for (const auto& det : kept) {
+        DetectionResult result;  // 统一输出检测结构。
+        result.id = det.cls_id;
+        result.score = det.score;
+        if (det.cls_id >= 0 && det.cls_id < static_cast<int>(config.labels.size())) {
+            result.label = config.labels[det.cls_id];
+        } else {
+            result.label = "cls_" + std::to_string(det.cls_id);
+        }
+        result.box.top = static_cast<int>(det.x1);
+        result.box.left = static_cast<int>(det.y1);
+        result.box.bottom = static_cast<int>(det.x2);
+        result.box.right = static_cast<int>(det.y2);
+        results.push_back(result);
+    }
+
+    return static_cast<int>(results.size());
+}
+

--- a/models/yolo26_post.h
+++ b/models/yolo26_post.h
@@ -1,0 +1,87 @@
+#pragma once
+
+#include <map>
+#include <string>
+#include <utility>
+#include <vector>
+
+#include "config.h"
+
+/**
+ * @brief YOLO26 单尺度分支张量描述。
+ */
+struct Yolo26HeadTensor {
+    int feat_h = 0;  // 特征图高度。
+    int feat_w = 0;  // 特征图宽度。
+    int num_cls = 0;  // 类别数。
+    std::vector<float> reg;  // 回归分支数据，布局为 [4, H, W]。
+    std::vector<float> cls;  // 分类分支数据，布局为 [C, H, W]。
+};
+
+/**
+ * @brief YOLO26 后处理器，负责解码与 NMS。
+ */
+class Yolo26PostProcessor {
+public:
+    /**
+     * @brief 构造后处理器。
+     * @param config YOLO26 配置。
+     */
+    explicit Yolo26PostProcessor(const YOLO26Config& config);
+
+    /**
+     * @brief 执行后处理。
+     * @param heads 各尺度 head 数据。
+     * @param orig_w 原图宽度。
+     * @param orig_h 原图高度。
+     * @param ratio_w 宽度缩放比例。
+     * @param ratio_h 高度缩放比例。
+     * @param results 输出检测框结果。
+     * @return int 有效检测框数量。
+     */
+    int run(const std::vector<Yolo26HeadTensor>& heads,
+            int orig_w,
+            int orig_h,
+            float ratio_w,
+            float ratio_h,
+            std::vector<DetectionResult>& results) const;
+
+private:
+    /**
+     * @brief 内部检测框结构。
+     */
+    struct Detection {
+        float x1 = 0.0f;  // 左上角 x。
+        float y1 = 0.0f;  // 左上角 y。
+        float x2 = 0.0f;  // 右下角 x。
+        float y2 = 0.0f;  // 右下角 y。
+        float score = 0.0f;  // 置信度。
+        int cls_id = -1;  // 类别 ID。
+    };
+
+    /**
+     * @brief 计算 Sigmoid。
+     * @param x 输入值。
+     * @return float 输出值。
+     */
+    static float sigmoid(float x);
+
+    /**
+     * @brief 计算 IoU。
+     * @param a 检测框 A。
+     * @param b 检测框 B。
+     * @return float IoU 值。
+     */
+    static float box_iou(const Detection& a, const Detection& b);
+
+    /**
+     * @brief 按类别执行 NMS。
+     * @param boxes 输入检测框。
+     * @param nms_thres NMS 阈值。
+     * @return std::vector<Detection> 保留检测框。
+     */
+    static std::vector<Detection> nms_per_class(const std::vector<Detection>& boxes, float nms_thres);
+
+    YOLO26Config config;  // 后处理配置。
+};
+

--- a/vp_node/CMakeLists.txt
+++ b/vp_node/CMakeLists.txt
@@ -2,6 +2,9 @@ cmake_minimum_required(VERSION 3.4.1)
 
 project(vp_node)
 
+find_package(PkgConfig REQUIRED)
+pkg_check_modules(SDL2 REQUIRED sdl2)
+
 file(GLOB_RECURSE SRC
         ${CMAKE_CURRENT_SOURCE_DIR}/excepts/*.cpp
         ${CMAKE_CURRENT_SOURCE_DIR}/nodes/*.cpp
@@ -15,11 +18,19 @@ target_include_directories(vp_node PUBLIC
     ${MPP_INCLUDES}
     ${RGA_INCLUDES}
     ${RKNN_RT_INCLUDES}
+    ${SDL2_INCLUDE_DIRS}
+)
+target_link_directories(vp_node PUBLIC
+    ${SDL2_LIBRARY_DIRS}
 )
 target_link_libraries(vp_node PUBLIC
     ${COMMON_LIBS}
+    ${SDL2_LIBRARIES}
     stdc++fs
     videocodec
     rknn_models
     bytetrack
+)
+target_compile_options(vp_node PRIVATE
+    ${SDL2_CFLAGS_OTHER}
 )

--- a/vp_node/nodes/base/vp_node.h
+++ b/vp_node/nodes/base/vp_node.h
@@ -60,6 +60,20 @@ namespace vp_nodes {
         // synchronize for out_queue
         vp_utils::vp_semaphore out_queue_semaphore;
 
+        // 节点 FPS 统计周期（毫秒）。
+        int node_fps_epoch_ms = 1000;
+        // 周期内累计帧数。
+        int node_fps_counter = 0;
+        // 上次打印 FPS 的时间点。
+        std::chrono::system_clock::time_point node_fps_last_time;
+
+        /**
+         * @brief 记录并按周期打印节点处理 FPS。
+         *
+         * @param stage 统计阶段标识（如 handle/dispatch）。
+         */
+        void log_node_fps_if_needed(const char* stage);
+
         // get meta from in_queue, handle meta and put them into out_queue looply.
         // we need re-implement(define how to create meta and put it into out_queue) in src nodes since they have no previous nodes. 
         virtual void handle_run();

--- a/vp_node/nodes/infer/vp_infer_node.cpp
+++ b/vp_node/nodes/infer/vp_infer_node.cpp
@@ -32,15 +32,17 @@ namespace vp_nodes {
                             swap_chn(swap_chn) {
         // try to load network from file,
         // failing means maybe it has a custom implementation for model loading in derived class such as using other backends other than opencv::dnn.
-        try {
-            net = cv::dnn::readNet(model_path, model_config_path);
-            #ifdef VP_WITH_CUDA
-            net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
-            net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
-            #endif
-        }
-        catch(const std::exception& e) {
-            VP_WARN(vp_utils::string_format("[%s] cv::dnn::readNet load network failed!", node_name.c_str()));
+        if (!model_path.empty()) {
+            try {
+                net = cv::dnn::readNet(model_path, model_config_path);
+                #ifdef VP_WITH_CUDA
+                net.setPreferableBackend(cv::dnn::DNN_BACKEND_CUDA);
+                net.setPreferableTarget(cv::dnn::DNN_TARGET_CUDA);
+                #endif
+            }
+            catch(const std::exception& e) {
+                VP_WARN(vp_utils::string_format("[%s] cv::dnn::readNet load network failed!", node_name.c_str()));
+            }
         }
 
         // load labels if labels_path is specified

--- a/vp_node/nodes/infer/vp_rk_first_yolo26.cpp
+++ b/vp_node/nodes/infer/vp_rk_first_yolo26.cpp
@@ -1,0 +1,73 @@
+#include "vp_rk_first_yolo26.h"
+
+#include <stdexcept>
+
+#include "vp_utils/vp_utils.h"
+
+namespace vp_nodes {
+vp_rk_first_yolo26::vp_rk_first_yolo26(std::string node_name, std::string json_path)
+    : vp_primary_infer_node(node_name, "") {
+    YOLO26Config conf;  // YOLO26 配置。
+    const int ret = YOLO26::load_config(json_path, conf);  // 配置加载结果。
+    if (ret != 0) {
+        throw std::runtime_error(vp_utils::string_format("[%s] load yolo26 config failed! path=%s ret=%d",
+                                                         node_name.c_str(),
+                                                         json_path.c_str(),
+                                                         ret));
+    }
+    rk_model = std::make_shared<YOLO26>(conf);
+    this->initialized();
+}
+
+vp_rk_first_yolo26::~vp_rk_first_yolo26() {
+    deinitialized();
+    rk_model.reset();
+}
+
+void vp_rk_first_yolo26::run_infer_combinations(
+    const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) {
+    assert(frame_meta_with_batch.size() == 1);
+    std::vector<cv::Mat> mats_to_infer;  // 待推理图像容器。
+
+    auto start_time = std::chrono::system_clock::now();  // 开始时间戳。
+    vp_primary_infer_node::prepare(frame_meta_with_batch, mats_to_infer);
+    const auto prepare_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now() - start_time);  // prepare 耗时。
+    if (mats_to_infer.empty()) {
+        return;
+    }
+
+    start_time = std::chrono::system_clock::now();
+    std::vector<DetectionResult> res;  // 检测结果。
+    rk_model->run(mats_to_infer[0], res);
+    auto infer_time = std::chrono::duration_cast<std::chrono::milliseconds>(
+        std::chrono::system_clock::now() - start_time);  // infer 耗时。
+
+    auto& frame_meta = frame_meta_with_batch[0];  // 当前帧元数据。
+    for (const auto& obj : res) {
+        auto target = std::make_shared<vp_objects::vp_frame_target>(obj.box.top,
+                                                                     obj.box.left,
+                                                                     obj.box.bottom - obj.box.top,
+                                                                     obj.box.right - obj.box.left,
+                                                                     obj.id,
+                                                                     obj.score,
+                                                                     frame_meta->frame_index,
+                                                                     frame_meta->channel_index,
+                                                                     obj.label);
+        frame_meta->targets.push_back(target);
+    }
+
+    vp_infer_node::infer_combinations_time_cost(static_cast<int>(mats_to_infer.size()),
+                                                static_cast<int>(prepare_time.count()),
+                                                0,
+                                                static_cast<int>(infer_time.count()),
+                                                0);
+}
+
+void vp_rk_first_yolo26::postprocess(
+    const std::vector<cv::Mat>& raw_outputs,
+    const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) {
+    (void)raw_outputs;
+    (void)frame_meta_with_batch;
+}
+}  // namespace vp_nodes

--- a/vp_node/nodes/infer/vp_rk_first_yolo26.h
+++ b/vp_node/nodes/infer/vp_rk_first_yolo26.h
@@ -1,0 +1,44 @@
+#pragma once
+
+#include "vp_primary_infer_node.h"
+#include "yolo26.h"
+
+namespace vp_nodes {
+/**
+ * @brief YOLO26 主检测节点（基于 RKNN）。
+ */
+class vp_rk_first_yolo26 : public vp_primary_infer_node {
+private:
+    std::shared_ptr<YOLO26> rk_model;  // YOLO26 模型对象。
+
+protected:
+    /**
+     * @brief 执行整帧推理组合流程。
+     * @param frame_meta_with_batch 批次帧元数据。
+     */
+    virtual void run_infer_combinations(
+        const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) override;
+
+    /**
+     * @brief 占位后处理接口（为满足基类纯虚函数）。
+     * @param raw_outputs 原始输出。
+     * @param frame_meta_with_batch 批次帧元数据。
+     */
+    virtual void postprocess(const std::vector<cv::Mat>& raw_outputs,
+                             const std::vector<std::shared_ptr<vp_objects::vp_frame_meta>>& frame_meta_with_batch) override;
+
+public:
+    /**
+     * @brief 构造 YOLO26 主检测节点。
+     * @param node_name 节点名称。
+     * @param json_path 配置文件路径。
+     */
+    vp_rk_first_yolo26(std::string node_name, std::string json_path);
+
+    /**
+     * @brief 析构函数。
+     */
+    ~vp_rk_first_yolo26();
+};
+}  // namespace vp_nodes
+

--- a/vp_node/nodes/vp_fakesink_des_node.cpp
+++ b/vp_node/nodes/vp_fakesink_des_node.cpp
@@ -1,0 +1,80 @@
+#include "vp_fakesink_des_node.h"
+
+#include "vp_utils/logger/vp_logger.h"
+#include "vp_utils/vp_utils.h"
+
+namespace vp_nodes {
+
+vp_fakesink_des_node::vp_fakesink_des_node(std::string node_name,
+                                           int channel_index,
+                                           bool osd,
+                                           std::string gst_encoder_name)
+    : vp_des_node(node_name, channel_index),
+      gst_encoder_name(std::move(gst_encoder_name)),
+      osd(osd) {
+    this->gst_pipeline = vp_utils::string_format(this->gst_template, this->gst_encoder_name.c_str());
+    VP_INFO(vp_utils::string_format("[%s] [%s]", this->node_name.c_str(), this->gst_pipeline.c_str()));
+    this->initialized();
+}
+
+vp_fakesink_des_node::~vp_fakesink_des_node() {
+    if (sink_writer.isOpened()) {
+        sink_writer.release();
+    }
+    deinitialized();
+}
+
+std::shared_ptr<vp_objects::vp_meta>
+vp_fakesink_des_node::handle_frame_meta(std::shared_ptr<vp_objects::vp_frame_meta> meta) {
+    // 待编码帧。
+    cv::Mat encode_frame = (osd && !meta->osd_frame.empty()) ? meta->osd_frame : meta->frame;
+    if (encode_frame.empty()) {
+        return vp_des_node::handle_frame_meta(meta);
+    }
+
+    if (!sink_writer.isOpened()) {
+        // 输出帧率（兜底 25fps）。
+        int output_fps = meta->fps > 0 ? meta->fps : 25;
+        const bool opened = sink_writer.open(
+            gst_pipeline,
+            cv::CAP_GSTREAMER,
+            0,
+            output_fps,
+            {encode_frame.cols, encode_frame.rows});
+        if (!opened) {
+            VP_ERROR(vp_utils::string_format("[%s] open gst writer failed: %s", node_name.c_str(), gst_pipeline.c_str()));
+            return vp_des_node::handle_frame_meta(meta);
+        }
+
+        fps_start_tp = std::chrono::steady_clock::now();
+        fps_last_log_tp = fps_start_tp;
+        encoded_frames = 0;
+    }
+
+    sink_writer.write(encode_frame);
+    encoded_frames++;
+
+    // 当前时间点。
+    const auto now_tp = std::chrono::steady_clock::now();
+    const auto log_delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_tp - fps_last_log_tp).count();
+    if (log_delta_ms >= 1000) {
+        // 总耗时毫秒。
+        const auto total_delta_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_tp - fps_start_tp).count();
+        // 平均 FPS。
+        const double avg_fps = total_delta_ms > 0 ? (encoded_frames * 1000.0 / static_cast<double>(total_delta_ms)) : 0.0;
+        VP_INFO(vp_utils::string_format("[%s] encode_to_fakesink fps=%.2f frames=%llu",
+                                        node_name.c_str(),
+                                        avg_fps,
+                                        static_cast<unsigned long long>(encoded_frames)));
+        fps_last_log_tp = now_tp;
+    }
+
+    return vp_des_node::handle_frame_meta(meta);
+}
+
+std::shared_ptr<vp_objects::vp_meta>
+vp_fakesink_des_node::handle_control_meta(std::shared_ptr<vp_objects::vp_control_meta> meta) {
+    return vp_des_node::handle_control_meta(meta);
+}
+
+} // namespace vp_nodes

--- a/vp_node/nodes/vp_fakesink_des_node.h
+++ b/vp_node/nodes/vp_fakesink_des_node.h
@@ -1,0 +1,76 @@
+#pragma once
+
+#include <chrono>
+#include <memory>
+#include <opencv2/core.hpp>
+#include <opencv2/videoio.hpp>
+#include <string>
+
+#include "nodes/base/vp_des_node.h"
+#include "objects/vp_control_meta.h"
+#include "objects/vp_frame_meta.h"
+
+namespace vp_nodes {
+
+/**
+ * @brief 编码并输出到 fakesink 的目标节点。
+ *
+ * 使用 OpenCV VideoWriter + GStreamer 管线，将输入帧编码后送入 fakesink，
+ * 便于评估“解码+编码”链路吞吐，不受显示端影响。
+ */
+class vp_fakesink_des_node : public vp_des_node {
+private:
+    // GStreamer 管线模板。
+    std::string gst_template = "appsrc ! videoconvert ! %s ! h264parse ! fakesink sync=false";
+    // 实际使用的 GStreamer 管线。
+    std::string gst_pipeline;
+    // OpenCV 输出器。
+    cv::VideoWriter sink_writer;
+
+    // 编码器名称。
+    std::string gst_encoder_name = "mpph264enc";
+    // 是否优先使用 OSD 帧。
+    bool osd = true;
+
+    // 已编码帧计数。
+    uint64_t encoded_frames = 0;
+    // FPS 统计起始时间。
+    std::chrono::steady_clock::time_point fps_start_tp;
+    // 上次打印 FPS 时间。
+    std::chrono::steady_clock::time_point fps_last_log_tp;
+
+protected:
+    /**
+     * @brief 处理输入视频帧并推送到编码+fakesink 管线。
+     * @param meta 输入帧元数据。
+     * @return std::shared_ptr<vp_objects::vp_meta> 始终返回 nullptr。
+     */
+    virtual std::shared_ptr<vp_objects::vp_meta> handle_frame_meta(std::shared_ptr<vp_objects::vp_frame_meta> meta) override;
+
+    /**
+     * @brief 处理控制元数据。
+     * @param meta 控制元数据。
+     * @return std::shared_ptr<vp_objects::vp_meta> 始终返回 nullptr。
+     */
+    virtual std::shared_ptr<vp_objects::vp_meta> handle_control_meta(std::shared_ptr<vp_objects::vp_control_meta> meta) override;
+
+public:
+    /**
+     * @brief 构造编码到 fakesink 的目标节点。
+     * @param node_name 节点名称。
+     * @param channel_index 通道索引。
+     * @param osd 是否优先使用 OSD 帧。
+     * @param gst_encoder_name GStreamer 编码器名称。
+     */
+    vp_fakesink_des_node(std::string node_name,
+                         int channel_index,
+                         bool osd = true,
+                         std::string gst_encoder_name = "mpph264enc");
+
+    /**
+     * @brief 析构并释放资源。
+     */
+    ~vp_fakesink_des_node();
+};
+
+} // namespace vp_nodes

--- a/vp_node/nodes/vp_file_src_node.h
+++ b/vp_node/nodes/vp_file_src_node.h
@@ -26,7 +26,9 @@ namespace vp_nodes {
                         float resize_ratio = 1.0, 
                         bool cycle = true,
                         std::string gst_decoder_name = "avdec_h264",
-                        int skip_interval = 0);
+                        int skip_interval = 0,
+                        bool throttle_by_source_fps = true,
+                        bool deep_copy_frame = true);
         ~vp_file_src_node();
 
         virtual std::string to_string() override;
@@ -37,6 +39,10 @@ namespace vp_nodes {
         std::string gst_decoder_name = "avdec_h264";
         // 0 means no skip
         int skip_interval = 0;
+        // 是否按源视频 FPS 节奏限速，true 表示实时播放，false 表示尽可能快解码。
+        bool throttle_by_source_fps = true;
+        // 是否对输入帧做深拷贝，false 可提升吞吐但在少数后端上可能出现帧复用风险。
+        bool deep_copy_frame = true;
     };
 
 }

--- a/vp_node/nodes/vp_mpp_sdl_src_node.cpp
+++ b/vp_node/nodes/vp_mpp_sdl_src_node.cpp
@@ -1,0 +1,931 @@
+#include "vp_mpp_sdl_src_node.h"
+
+#include <chrono>
+#include <cstring>
+#include <thread>
+#include <unistd.h>
+
+#include <opencv2/imgproc.hpp>
+
+#include "vp_utils/logger/vp_logger.h"
+#include "vp_utils/vp_utils.h"
+
+namespace vp_nodes {
+
+namespace {
+// MPP 输入分片大小，避免超大包一次性提交造成阻塞。
+constexpr size_t k_input_chunk_size = 4096;
+
+/**
+ * @brief 将 FFmpeg 错误码转换为可读字符串。
+ * @param err FFmpeg 错误码。
+ * @return std::string 可读错误文本。
+ */
+std::string ff_err_to_string(int err) {
+    // FFmpeg 错误缓冲。
+    char err_buf[128] = {0};
+    av_strerror(err, err_buf, sizeof(err_buf));
+    return std::string(err_buf);
+}
+} // namespace
+
+uint64_t vp_mpp_sdl_src_node::now_us() {
+    return static_cast<uint64_t>(std::chrono::duration_cast<std::chrono::microseconds>(
+        std::chrono::steady_clock::now().time_since_epoch()).count());
+}
+
+bool vp_mpp_sdl_src_node::map_dec_codec(AVCodecID codec_id, MppCodingType& out_coding, const char*& out_bsf_name) {
+    switch (codec_id) {
+    case AV_CODEC_ID_H264:
+        out_coding = MPP_VIDEO_CodingAVC;
+        out_bsf_name = "h264_mp4toannexb";
+        return true;
+    case AV_CODEC_ID_HEVC:
+        out_coding = MPP_VIDEO_CodingHEVC;
+        out_bsf_name = "hevc_mp4toannexb";
+        return true;
+    default:
+        return false;
+    }
+}
+
+vp_mpp_sdl_src_node::vp_mpp_sdl_src_node(std::string node_name,
+                                         int channel_index,
+                                         std::string file_path,
+                                         bool cycle,
+                                         bool pace_by_src_fps,
+                                         bool enable_vsync,
+                                         bool disable_overlay,
+                                         bool fullscreen,
+                                         bool render_to_screen,
+                                         bool publish_frame_meta,
+                                         std::string sdl_video_driver,
+                                         std::string sdl_render_driver)
+    : vp_src_node(node_name, channel_index, 1.0f),
+      file_path(std::move(file_path)),
+      cycle(cycle),
+      pace_by_src_fps(pace_by_src_fps),
+      enable_vsync(enable_vsync),
+      disable_overlay(disable_overlay),
+      fullscreen(fullscreen),
+      render_to_screen(render_to_screen),
+      publish_frame_meta(publish_frame_meta),
+      sdl_video_driver(std::move(sdl_video_driver)),
+      sdl_render_driver(std::move(sdl_render_driver)) {
+    VP_INFO(vp_utils::string_format("[%s] file=%s cycle=%d pace=%d vsync=%d fullscreen=%d render=%d publish_meta=%d",
+                                    this->node_name.c_str(),
+                                    this->file_path.c_str(),
+                                    this->cycle ? 1 : 0,
+                                    this->pace_by_src_fps ? 1 : 0,
+                                    this->enable_vsync ? 1 : 0,
+                                    this->fullscreen ? 1 : 0,
+                                    this->render_to_screen ? 1 : 0,
+                                    this->publish_frame_meta ? 1 : 0));
+    this->initialized();
+}
+
+vp_mpp_sdl_src_node::~vp_mpp_sdl_src_node() {
+    deinitialized();
+}
+
+bool vp_mpp_sdl_src_node::init_demux() {
+    // 输入打开返回值。
+    int ret = avformat_open_input(&ifmt, file_path.c_str(), nullptr, nullptr);
+    if (ret < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] avformat_open_input failed: %s",
+                                         node_name.c_str(), ff_err_to_string(ret).c_str()));
+        return false;
+    }
+
+    // 读取流信息返回值。
+    ret = avformat_find_stream_info(ifmt, nullptr);
+    if (ret < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] avformat_find_stream_info failed: %s",
+                                         node_name.c_str(), ff_err_to_string(ret).c_str()));
+        return false;
+    }
+
+    // 视频流索引。
+    video_index = av_find_best_stream(ifmt, AVMEDIA_TYPE_VIDEO, -1, -1, nullptr, 0);
+    if (video_index < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] no video stream found in %s", node_name.c_str(), file_path.c_str()));
+        return false;
+    }
+
+    // 视频流指针。
+    AVStream* video_stream = ifmt->streams[video_index];
+    // 首选平均帧率。
+    AVRational frame_rate = video_stream->avg_frame_rate;
+    if (frame_rate.num <= 0 || frame_rate.den <= 0) {
+        frame_rate = video_stream->r_frame_rate;
+    }
+
+    if (frame_rate.num > 0 && frame_rate.den > 0) {
+        // 源视频 FPS。
+        const double fps = av_q2d(frame_rate);
+        if (fps > 1.0 && fps < 240.0) {
+            frame_interval_us = static_cast<uint64_t>(1000000.0 / fps);
+            original_fps = static_cast<int>(fps);
+        }
+    }
+    if (frame_interval_us == 0) {
+        frame_interval_us = 20000;  // 默认 50 FPS 节奏。
+    }
+    if (original_fps <= 0) {
+        original_fps = 50;
+    }
+
+    original_width = video_stream->codecpar->width;
+    original_height = video_stream->codecpar->height;
+
+    // bsf 名称。
+    const char* bsf_name = nullptr;
+    if (!map_dec_codec(video_stream->codecpar->codec_id, coding, bsf_name)) {
+        VP_ERROR(vp_utils::string_format("[%s] unsupported codec, only H264/H265 are supported", node_name.c_str()));
+        return false;
+    }
+
+    // bsf 描述符。
+    const AVBitStreamFilter* bsf = av_bsf_get_by_name(bsf_name);
+    if (!bsf) {
+        VP_ERROR(vp_utils::string_format("[%s] av_bsf_get_by_name failed: %s", node_name.c_str(), bsf_name));
+        return false;
+    }
+
+    ret = av_bsf_alloc(bsf, &ibsfc);
+    if (ret < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] av_bsf_alloc failed: %s",
+                                         node_name.c_str(), ff_err_to_string(ret).c_str()));
+        return false;
+    }
+
+    ret = avcodec_parameters_copy(ibsfc->par_in, video_stream->codecpar);
+    if (ret < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] avcodec_parameters_copy failed: %s",
+                                         node_name.c_str(), ff_err_to_string(ret).c_str()));
+        return false;
+    }
+
+    ibsfc->time_base_in = video_stream->time_base;
+    ret = av_bsf_init(ibsfc);
+    if (ret < 0) {
+        VP_ERROR(vp_utils::string_format("[%s] av_bsf_init failed: %s",
+                                         node_name.c_str(), ff_err_to_string(ret).c_str()));
+        return false;
+    }
+
+    VP_INFO(vp_utils::string_format("[%s] demux ready w=%d h=%d fps=%d codec=%d",
+                                    node_name.c_str(), original_width, original_height, original_fps, coding));
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::init_decoder() {
+    // MPP 返回值。
+    MPP_RET ret = mpp_create(&dec_ctx, &dec_mpi);
+    if (ret) {
+        VP_ERROR(vp_utils::string_format("[%s] mpp_create failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    ret = mpp_init(dec_ctx, MPP_CTX_DEC, coding);
+    if (ret) {
+        VP_ERROR(vp_utils::string_format("[%s] mpp_init failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    // 解码配置对象。
+    MppDecCfg cfg = nullptr;
+    ret = mpp_dec_cfg_init(&cfg);
+    if (ret) {
+        VP_ERROR(vp_utils::string_format("[%s] mpp_dec_cfg_init failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    ret = dec_mpi->control(dec_ctx, MPP_DEC_GET_CFG, cfg);
+    if (ret) {
+        mpp_dec_cfg_deinit(cfg);
+        VP_ERROR(vp_utils::string_format("[%s] MPP_DEC_GET_CFG failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    ret = mpp_dec_cfg_set_u32(cfg, "base:split_parse", 1);
+    if (ret) {
+        mpp_dec_cfg_deinit(cfg);
+        VP_ERROR(vp_utils::string_format("[%s] mpp_dec_cfg_set_u32 split_parse failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    ret = dec_mpi->control(dec_ctx, MPP_DEC_SET_CFG, cfg);
+    mpp_dec_cfg_deinit(cfg);
+    if (ret) {
+        VP_ERROR(vp_utils::string_format("[%s] MPP_DEC_SET_CFG failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    // 强制 NV12 输出格式。
+    MppFrameFormat output_format = MPP_FMT_YUV420SP;
+    ret = dec_mpi->control(dec_ctx, MPP_DEC_SET_OUTPUT_FORMAT, &output_format);
+    if (ret) {
+        VP_WARN(vp_utils::string_format("[%s] MPP_DEC_SET_OUTPUT_FORMAT failed: %d", node_name.c_str(), ret));
+    }
+
+    ret = mpp_packet_init(&dec_pkt, nullptr, 0);
+    if (ret) {
+        VP_ERROR(vp_utils::string_format("[%s] mpp_packet_init failed: %d", node_name.c_str(), ret));
+        return false;
+    }
+
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::init_sdl_for_frame(MppFrame frame) {
+    width = static_cast<int>(mpp_frame_get_width(frame));
+    height = static_cast<int>(mpp_frame_get_height(frame));
+    stride_h = static_cast<int>(mpp_frame_get_hor_stride(frame));
+    stride_v = static_cast<int>(mpp_frame_get_ver_stride(frame));
+
+    if (!sdl_video_driver.empty()) {
+        // 设置 SDL 视频驱动返回值。
+        const int set_env_ret = setenv("SDL_VIDEODRIVER", sdl_video_driver.c_str(), 1);
+        if (set_env_ret != 0) {
+            VP_WARN(vp_utils::string_format("[%s] set SDL_VIDEODRIVER failed", node_name.c_str()));
+        }
+    }
+    if (!sdl_render_driver.empty()) {
+        // 对齐 mpp 示例：通过环境变量指定渲染驱动。
+        const int set_hint_env_ret = setenv("SDL_HINT_RENDER_DRIVER", sdl_render_driver.c_str(), 1);
+        if (set_hint_env_ret != 0) {
+            VP_WARN(vp_utils::string_format("[%s] set SDL_HINT_RENDER_DRIVER failed", node_name.c_str()));
+        }
+    }
+
+    SDL_SetHint(SDL_HINT_RENDER_SCALE_QUALITY, "0");
+    SDL_SetHint(SDL_HINT_RENDER_BATCHING, "1");
+    SDL_SetHint(SDL_HINT_RENDER_VSYNC, enable_vsync ? "1" : "0");
+#ifdef SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR
+    SDL_SetHint(SDL_HINT_VIDEO_X11_NET_WM_BYPASS_COMPOSITOR, "1");
+#endif
+#ifdef SDL_HINT_VIDEO_X11_FORCE_EGL
+    SDL_SetHint(SDL_HINT_VIDEO_X11_FORCE_EGL, "1");
+#endif
+
+    if (SDL_Init(SDL_INIT_VIDEO) != 0) {
+        VP_ERROR(vp_utils::string_format("[%s] SDL_Init failed: %s", node_name.c_str(), SDL_GetError()));
+        return false;
+    }
+
+    // 窗口标志。
+    Uint32 window_flags = SDL_WINDOW_SHOWN | SDL_WINDOW_RESIZABLE;
+    if (fullscreen) {
+        window_flags |= SDL_WINDOW_FULLSCREEN_DESKTOP;
+    }
+    sdl_window = SDL_CreateWindow(
+        "RK_VideoPipe MPP SDL Player",
+        SDL_WINDOWPOS_CENTERED,
+        SDL_WINDOWPOS_CENTERED,
+        width,
+        height,
+        window_flags);
+    if (!sdl_window) {
+        VP_ERROR(vp_utils::string_format("[%s] SDL_CreateWindow failed: %s", node_name.c_str(), SDL_GetError()));
+        return false;
+    }
+
+    // 渲染器标志。
+    Uint32 renderer_flags = SDL_RENDERER_ACCELERATED;
+    if (enable_vsync) {
+        renderer_flags |= SDL_RENDERER_PRESENTVSYNC;
+    }
+    // 指定渲染器索引，默认自动。
+    int render_index = -1;
+    if (!sdl_render_driver.empty()) {
+        const int driver_count = SDL_GetNumRenderDrivers();
+        for (int i = 0; i < driver_count; ++i) {
+            // 渲染器信息。
+            SDL_RendererInfo renderer_info;
+            if (SDL_GetRenderDriverInfo(i, &renderer_info) == 0 &&
+                renderer_info.name != nullptr &&
+                !strcmp(renderer_info.name, sdl_render_driver.c_str())) {
+                render_index = i;
+                break;
+            }
+        }
+        if (render_index < 0) {
+            VP_WARN(vp_utils::string_format("[%s] render driver %s not found, fallback auto",
+                                            node_name.c_str(), sdl_render_driver.c_str()));
+        }
+    }
+    sdl_renderer = SDL_CreateRenderer(sdl_window, render_index, renderer_flags);
+    if (!sdl_renderer) {
+        VP_WARN(vp_utils::string_format("[%s] SDL accelerated renderer failed: %s, fallback",
+                                        node_name.c_str(), SDL_GetError()));
+        sdl_renderer = SDL_CreateRenderer(sdl_window, -1, enable_vsync ? SDL_RENDERER_PRESENTVSYNC : 0);
+        if (!sdl_renderer) {
+            VP_ERROR(vp_utils::string_format("[%s] SDL_CreateRenderer failed: %s", node_name.c_str(), SDL_GetError()));
+            return false;
+        }
+    }
+
+    // 当前渲染器信息。
+    SDL_RendererInfo active_renderer_info;
+    if (SDL_GetRendererInfo(sdl_renderer, &active_renderer_info) == 0) {
+        VP_INFO(vp_utils::string_format("[%s] SDL video_driver=%s render_driver=%s flags=0x%x",
+                                        node_name.c_str(),
+                                        SDL_GetCurrentVideoDriver() ? SDL_GetCurrentVideoDriver() : "unknown",
+                                        active_renderer_info.name ? active_renderer_info.name : "unknown",
+                                        active_renderer_info.flags));
+    }
+
+    sdl_texture = SDL_CreateTexture(sdl_renderer,
+                                    SDL_PIXELFORMAT_NV12,
+                                    SDL_TEXTUREACCESS_STREAMING,
+                                    width,
+                                    height);
+    if (!sdl_texture) {
+        VP_ERROR(vp_utils::string_format("[%s] SDL_CreateTexture NV12 failed: %s", node_name.c_str(), SDL_GetError()));
+        return false;
+    }
+
+    sdl_inited = true;
+    VP_INFO(vp_utils::string_format("[%s] sdl ready w=%d h=%d stride=%d:%d",
+                                    node_name.c_str(), width, height, stride_h, stride_v));
+    return true;
+}
+
+void vp_mpp_sdl_src_node::pump_sdl_events() {
+    // SDL 事件对象。
+    SDL_Event event;
+    while (SDL_PollEvent(&event)) {
+        if (event.type == SDL_QUIT) {
+            quit = true;
+        }
+        if (event.type == SDL_KEYDOWN && event.key.keysym.sym == SDLK_ESCAPE) {
+            quit = true;
+        }
+    }
+}
+
+void vp_mpp_sdl_src_node::log_runtime_fps() {
+    if (fps_start_us == 0 || dec_frames == 0) {
+        return;
+    }
+
+    // 当前时间。
+    const uint64_t now = now_us();
+    if (fps_last_log_us == 0) {
+        fps_last_log_us = now;
+        fps_last_log_frames = dec_frames;
+        return;
+    }
+
+    // 距上次日志时间间隔。
+    const uint64_t delta_us = now - fps_last_log_us;
+    if (delta_us < 1000000) {
+        return;
+    }
+
+    // 距上次日志新增帧数。
+    const uint32_t delta_frames = dec_frames - fps_last_log_frames;
+    // 当前 FPS。
+    const double cur_fps = delta_us ? (static_cast<double>(delta_frames) * 1000000.0 / static_cast<double>(delta_us)) : 0.0;
+    // 总运行时长。
+    const uint64_t total_us = now - fps_start_us;
+    // 平均 FPS。
+    const double avg_fps = total_us ? (static_cast<double>(dec_frames) * 1000000.0 / static_cast<double>(total_us)) : 0.0;
+
+    VP_INFO(vp_utils::string_format("[%s] current_fps=%.2f avg_fps=%.2f frames=%u",
+                                    node_name.c_str(), cur_fps, avg_fps, dec_frames));
+
+    fps_last_log_us = now;
+    fps_last_log_frames = dec_frames;
+}
+
+bool vp_mpp_sdl_src_node::render_frame_nv12(MppFrame frame) {
+    // MPP buffer。
+    MppBuffer buffer = mpp_frame_get_buffer(frame);
+    if (!buffer) {
+        VP_WARN(vp_utils::string_format("[%s] frame has no buffer", node_name.c_str()));
+        return false;
+    }
+
+    // NV12 基地址。
+    auto* base = static_cast<RK_U8*>(mpp_buffer_get_ptr(buffer));
+    if (!base) {
+        VP_WARN(vp_utils::string_format("[%s] mpp buffer ptr is null", node_name.c_str()));
+        return false;
+    }
+
+    // Y 平面指针。
+    const RK_U8* y_plane = base;
+    // UV 平面指针。
+    const RK_U8* uv_plane = base + static_cast<size_t>(stride_h) * static_cast<size_t>(stride_v);
+
+    // SDL lock 输出像素首地址。
+    void* pixels = nullptr;
+    // SDL 输出步长。
+    int pitch = 0;
+    if (SDL_LockTexture(sdl_texture, nullptr, &pixels, &pitch) != 0) {
+        VP_WARN(vp_utils::string_format("[%s] SDL_LockTexture failed: %s", node_name.c_str(), SDL_GetError()));
+        return false;
+    }
+
+    if (!pixels || pitch <= 0) {
+        SDL_UnlockTexture(sdl_texture);
+        return false;
+    }
+
+    // SDL Y 平面目的地址。
+    auto* dst_y = static_cast<uint8_t*>(pixels);
+    // SDL UV 平面目的地址。
+    auto* dst_uv = dst_y + static_cast<size_t>(pitch) * static_cast<size_t>(height);
+
+    for (int row = 0; row < height; ++row) {
+        memcpy(dst_y + static_cast<size_t>(row) * static_cast<size_t>(pitch),
+               y_plane + static_cast<size_t>(row) * static_cast<size_t>(stride_h),
+               static_cast<size_t>(width));
+    }
+
+    for (int row = 0; row < height / 2; ++row) {
+        memcpy(dst_uv + static_cast<size_t>(row) * static_cast<size_t>(pitch),
+               uv_plane + static_cast<size_t>(row) * static_cast<size_t>(stride_h),
+               static_cast<size_t>(width));
+    }
+
+    SDL_UnlockTexture(sdl_texture);
+
+    if (SDL_RenderCopy(sdl_renderer, sdl_texture, nullptr, nullptr) != 0) {
+        VP_WARN(vp_utils::string_format("[%s] SDL_RenderCopy failed: %s", node_name.c_str(), SDL_GetError()));
+        return false;
+    }
+
+    SDL_RenderPresent(sdl_renderer);
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::setup_info_change(MppFrame frame) {
+    if (!dec_frm_grp) {
+        // 创建内部 buffer group 返回值。
+        const MPP_RET group_ret = mpp_buffer_group_get_internal(&dec_frm_grp, MPP_BUFFER_TYPE_ION);
+        if (group_ret) {
+            VP_ERROR(vp_utils::string_format("[%s] mpp_buffer_group_get_internal failed: %d", node_name.c_str(), group_ret));
+            return false;
+        }
+    }
+
+    // 单帧缓冲需求大小。
+    const RK_U32 buf_size = mpp_frame_get_buf_size(frame);
+    if (mpp_buffer_group_limit_config(dec_frm_grp, buf_size, 24)) {
+        VP_ERROR(vp_utils::string_format("[%s] mpp_buffer_group_limit_config failed", node_name.c_str()));
+        return false;
+    }
+    if (dec_mpi->control(dec_ctx, MPP_DEC_SET_EXT_BUF_GROUP, dec_frm_grp)) {
+        VP_ERROR(vp_utils::string_format("[%s] MPP_DEC_SET_EXT_BUF_GROUP failed", node_name.c_str()));
+        return false;
+    }
+    if (dec_mpi->control(dec_ctx, MPP_DEC_SET_INFO_CHANGE_READY, nullptr)) {
+        VP_ERROR(vp_utils::string_format("[%s] MPP_DEC_SET_INFO_CHANGE_READY failed", node_name.c_str()));
+        return false;
+    }
+
+    if (render_to_screen) {
+        if (!sdl_inited && !init_sdl_for_frame(frame)) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+void vp_mpp_sdl_src_node::publish_frame_meta_if_needed(MppFrame frame) {
+    if (!publish_frame_meta) {
+        return;
+    }
+
+    // MPP buffer。
+    MppBuffer buffer = mpp_frame_get_buffer(frame);
+    if (!buffer) {
+        return;
+    }
+
+    // NV12 基地址。
+    auto* base = static_cast<RK_U8*>(mpp_buffer_get_ptr(buffer));
+    if (!base) {
+        return;
+    }
+
+    // 当前帧宽度。
+    const int frame_width = static_cast<int>(mpp_frame_get_width(frame));
+    // 当前帧高度。
+    const int frame_height = static_cast<int>(mpp_frame_get_height(frame));
+    // 当前水平 stride。
+    const int frame_stride_h = static_cast<int>(mpp_frame_get_hor_stride(frame));
+    // 当前垂直 stride。
+    const int frame_stride_v = static_cast<int>(mpp_frame_get_ver_stride(frame));
+
+    if (frame_width <= 0 || frame_height <= 0 || frame_stride_h < frame_width || frame_stride_v < frame_height) {
+        return;
+    }
+
+    // NV12 原始矩阵（含 stride 区域）。
+    cv::Mat nv12_mat(frame_stride_v * 3 / 2, frame_stride_h, CV_8UC1, base);
+    // BGR 全尺寸图像（宽度为 stride）。
+    cv::Mat bgr_full;
+    cv::cvtColor(nv12_mat, bgr_full, cv::COLOR_YUV2BGR_NV12);
+
+    if (bgr_full.cols < frame_width || bgr_full.rows < frame_height) {
+        return;
+    }
+
+    // 裁剪有效显示区域。
+    cv::Mat bgr_roi = bgr_full(cv::Rect(0, 0, frame_width, frame_height));
+
+    // 输出帧（深拷贝，避免底层内存复用导致野指针）。
+    cv::Mat output_frame = bgr_roi.clone();
+    if (output_frame.empty()) {
+        return;
+    }
+
+    this->frame_index++;
+    // 下游输出 meta。
+    auto out_meta = std::make_shared<vp_objects::vp_frame_meta>(
+        output_frame,
+        this->frame_index,
+        this->channel_index,
+        frame_width,
+        frame_height,
+        this->original_fps);
+
+    this->out_queue.push(out_meta);
+    if (this->meta_handled_hooker) {
+        meta_handled_hooker(node_name, out_queue.size(), out_meta);
+    }
+    this->out_queue_semaphore.signal();
+}
+
+bool vp_mpp_sdl_src_node::process_decoded_frame(MppFrame frame, bool& got_eos) {
+    if (mpp_frame_get_info_change(frame)) {
+        return setup_info_change(frame);
+    }
+
+    // 错误标志。
+    const RK_U32 err_info = mpp_frame_get_errinfo(frame);
+    // 丢弃标志。
+    const RK_U32 discard = mpp_frame_get_discard(frame);
+    if (!err_info && !discard) {
+        if (fps_start_us == 0) {
+            fps_start_us = now_us();
+            play_start_us = fps_start_us;
+        }
+
+        if (pace_by_src_fps && play_start_us && frame_interval_us) {
+            // 当前时间。
+            const uint64_t now = now_us();
+            // 当前帧目标展示时间。
+            const uint64_t target = play_start_us + static_cast<uint64_t>(shown_frames) * frame_interval_us;
+            if (target > now) {
+                // 需要等待的微秒数。
+                const uint64_t wait_us = target - now;
+                if (wait_us > 200) {
+                    usleep(static_cast<useconds_t>(wait_us));
+                }
+            }
+        }
+
+        dec_frames++;
+        log_runtime_fps();
+
+        if (render_to_screen && sdl_inited && !render_frame_nv12(frame)) {
+            return false;
+        }
+        shown_frames++;
+
+        publish_frame_meta_if_needed(frame);
+    }
+
+    if (mpp_frame_get_eos(frame)) {
+        got_eos = true;
+    }
+
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::poll_decoder_frames(bool& got_eos) {
+    // 超时重试计数。
+    int timeout_retry = 20;
+    while (alive && !quit) {
+        // 取出的解码帧。
+        MppFrame frame = nullptr;
+        // MPP 返回值。
+        const MPP_RET ret = dec_mpi->decode_get_frame(dec_ctx, &frame);
+
+        if (ret == MPP_ERR_TIMEOUT) {
+            if (timeout_retry-- > 0) {
+                usleep(1000);
+                continue;
+            }
+            return true;
+        }
+        if (ret != MPP_OK) {
+            VP_ERROR(vp_utils::string_format("[%s] decode_get_frame failed: %d", node_name.c_str(), ret));
+            return false;
+        }
+        if (!frame) {
+            return true;
+        }
+
+        // 当前帧处理结果。
+        const bool ok = process_decoded_frame(frame, got_eos);
+        mpp_frame_deinit(&frame);
+        pump_sdl_events();
+        if (!ok) {
+            return false;
+        }
+    }
+
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::put_dec_packet_retry(bool& got_eos) {
+    // 提交重试次数。
+    int retry = 2000;
+    while (retry-- > 0 && alive && !quit) {
+        // 提交 packet 返回值。
+        const MPP_RET ret = dec_mpi->decode_put_packet(dec_ctx, dec_pkt);
+        if (ret == MPP_OK) {
+            return true;
+        }
+        if (!poll_decoder_frames(got_eos)) {
+            return false;
+        }
+        usleep(1000);
+    }
+
+    VP_ERROR(vp_utils::string_format("[%s] decode_put_packet timeout", node_name.c_str()));
+    return false;
+}
+
+bool vp_mpp_sdl_src_node::send_to_decoder(const AVPacket* packet, bool eos, bool& got_eos) {
+    // 输入数据首地址。
+    RK_U8* data = packet ? packet->data : nullptr;
+    // 输入总长度。
+    size_t total_size = packet ? static_cast<size_t>(packet->size) : 0;
+    // 当前偏移。
+    size_t offset = 0;
+
+    if (total_size == 0) {
+        mpp_packet_set_data(dec_pkt, nullptr);
+        mpp_packet_set_pos(dec_pkt, nullptr);
+        mpp_packet_set_size(dec_pkt, 0);
+        mpp_packet_set_length(dec_pkt, 0);
+        if (eos) {
+            mpp_packet_set_eos(dec_pkt);
+        } else {
+            mpp_packet_clr_eos(dec_pkt);
+        }
+        return put_dec_packet_retry(got_eos);
+    }
+
+    while (offset < total_size && alive && !quit) {
+        // 本次提交分片长度。
+        size_t chunk = total_size - offset;
+        if (chunk > k_input_chunk_size) {
+            chunk = k_input_chunk_size;
+        }
+
+        mpp_packet_set_data(dec_pkt, data + offset);
+        mpp_packet_set_pos(dec_pkt, data + offset);
+        mpp_packet_set_size(dec_pkt, chunk);
+        mpp_packet_set_length(dec_pkt, chunk);
+        if (eos && offset + chunk == total_size) {
+            mpp_packet_set_eos(dec_pkt);
+        } else {
+            mpp_packet_clr_eos(dec_pkt);
+        }
+
+        while (mpp_packet_get_length(dec_pkt) > 0 && alive && !quit) {
+            if (!put_dec_packet_retry(got_eos)) {
+                return false;
+            }
+        }
+
+        offset += chunk;
+    }
+
+    return true;
+}
+
+bool vp_mpp_sdl_src_node::run_pipeline_once() {
+    // 输入 packet。
+    AVPacket* input_packet = av_packet_alloc();
+    // 过滤后 packet。
+    AVPacket* filtered_packet = av_packet_alloc();
+    // 是否拿到 eos。
+    bool got_eos = false;
+
+    if (!input_packet || !filtered_packet) {
+        if (input_packet) {
+            av_packet_free(&input_packet);
+        }
+        if (filtered_packet) {
+            av_packet_free(&filtered_packet);
+        }
+        VP_ERROR(vp_utils::string_format("[%s] av_packet_alloc failed", node_name.c_str()));
+        return false;
+    }
+
+    while (alive && !quit && av_read_frame(ifmt, input_packet) >= 0) {
+        if (input_packet->stream_index == video_index) {
+            // bsf 输入返回值。
+            int ret = av_bsf_send_packet(ibsfc, input_packet);
+            if (ret < 0) {
+                VP_ERROR(vp_utils::string_format("[%s] av_bsf_send_packet failed: %s",
+                                                 node_name.c_str(), ff_err_to_string(ret).c_str()));
+                av_packet_unref(input_packet);
+                av_packet_free(&input_packet);
+                av_packet_free(&filtered_packet);
+                return false;
+            }
+
+            // bsf 输出返回值（初始化为 EAGAIN，避免短路时误判）。
+            int receive_ret = AVERROR(EAGAIN);
+            while (alive && !quit && (receive_ret = av_bsf_receive_packet(ibsfc, filtered_packet)) >= 0) {
+                if (!send_to_decoder(filtered_packet, false, got_eos)) {
+                    av_packet_unref(filtered_packet);
+                    av_packet_unref(input_packet);
+                    av_packet_free(&input_packet);
+                    av_packet_free(&filtered_packet);
+                    return false;
+                }
+                if (!poll_decoder_frames(got_eos)) {
+                    av_packet_unref(filtered_packet);
+                    av_packet_unref(input_packet);
+                    av_packet_free(&input_packet);
+                    av_packet_free(&filtered_packet);
+                    return false;
+                }
+                av_packet_unref(filtered_packet);
+            }
+
+            if (!quit && receive_ret != AVERROR(EAGAIN) && receive_ret != AVERROR_EOF) {
+                VP_ERROR(vp_utils::string_format("[%s] av_bsf_receive_packet failed: %s",
+                                                 node_name.c_str(), ff_err_to_string(receive_ret).c_str()));
+                av_packet_unref(input_packet);
+                av_packet_free(&input_packet);
+                av_packet_free(&filtered_packet);
+                return false;
+            }
+        }
+
+        av_packet_unref(input_packet);
+        pump_sdl_events();
+    }
+
+    if (alive && !quit) {
+        if (av_bsf_send_packet(ibsfc, nullptr) < 0) {
+            av_packet_free(&input_packet);
+            av_packet_free(&filtered_packet);
+            return false;
+        }
+
+        while (alive && !quit) {
+            // bsf 输出返回值。
+            const int ret = av_bsf_receive_packet(ibsfc, filtered_packet);
+            if (ret == AVERROR_EOF || ret == AVERROR(EAGAIN)) {
+                break;
+            }
+            if (ret < 0) {
+                VP_ERROR(vp_utils::string_format("[%s] av_bsf_receive_packet(flush) failed: %s",
+                                                 node_name.c_str(), ff_err_to_string(ret).c_str()));
+                av_packet_free(&input_packet);
+                av_packet_free(&filtered_packet);
+                return false;
+            }
+
+            if (!send_to_decoder(filtered_packet, false, got_eos) || !poll_decoder_frames(got_eos)) {
+                av_packet_unref(filtered_packet);
+                av_packet_free(&input_packet);
+                av_packet_free(&filtered_packet);
+                return false;
+            }
+            av_packet_unref(filtered_packet);
+        }
+
+        if (!send_to_decoder(nullptr, true, got_eos)) {
+            av_packet_free(&input_packet);
+            av_packet_free(&filtered_packet);
+            return false;
+        }
+
+        for (int i = 0; i < 3000 && !got_eos && alive && !quit; ++i) {
+            if (!poll_decoder_frames(got_eos)) {
+                av_packet_free(&input_packet);
+                av_packet_free(&filtered_packet);
+                return false;
+            }
+            usleep(1000);
+            pump_sdl_events();
+        }
+    }
+
+    av_packet_free(&input_packet);
+    av_packet_free(&filtered_packet);
+    return true;
+}
+
+void vp_mpp_sdl_src_node::cleanup() {
+    if (sdl_texture) {
+        SDL_DestroyTexture(sdl_texture);
+        sdl_texture = nullptr;
+    }
+    if (sdl_renderer) {
+        SDL_DestroyRenderer(sdl_renderer);
+        sdl_renderer = nullptr;
+    }
+    if (sdl_window) {
+        SDL_DestroyWindow(sdl_window);
+        sdl_window = nullptr;
+    }
+    if (sdl_inited) {
+        SDL_Quit();
+        sdl_inited = false;
+    }
+
+    if (dec_frm_grp) {
+        mpp_buffer_group_put(dec_frm_grp);
+        dec_frm_grp = nullptr;
+    }
+    if (dec_pkt) {
+        mpp_packet_deinit(&dec_pkt);
+        dec_pkt = nullptr;
+    }
+    if (dec_ctx) {
+        mpp_destroy(dec_ctx);
+        dec_ctx = nullptr;
+        dec_mpi = nullptr;
+    }
+
+    if (ibsfc) {
+        av_bsf_free(&ibsfc);
+        ibsfc = nullptr;
+    }
+    if (ifmt) {
+        avformat_close_input(&ifmt);
+        ifmt = nullptr;
+    }
+
+    width = 0;
+    height = 0;
+    stride_h = 0;
+    stride_v = 0;
+}
+
+void vp_mpp_sdl_src_node::handle_run() {
+    while (alive) {
+        gate.knock();
+        if (!alive) {
+            break;
+        }
+
+        quit = false;
+        dec_frames = 0;
+        shown_frames = 0;
+        fps_start_us = 0;
+        fps_last_log_us = 0;
+        fps_last_log_frames = 0;
+        play_start_us = 0;
+
+        if (!init_demux() || !init_decoder()) {
+            cleanup();
+            VP_ERROR(vp_utils::string_format("[%s] init failed, retry in 1s", node_name.c_str()));
+            std::this_thread::sleep_for(std::chrono::seconds(1));
+            continue;
+        }
+
+        vp_stream_info stream_info{channel_index, original_fps, original_width, original_height, to_string()};
+        invoke_stream_info_hooker(node_name, stream_info);
+
+        const bool ok = run_pipeline_once();
+        const uint64_t elapsed_us = (fps_start_us && dec_frames > 0) ? (now_us() - fps_start_us) : 0;
+        const double avg_fps = elapsed_us ? (static_cast<double>(dec_frames) * 1000000.0 / static_cast<double>(elapsed_us)) : 0.0;
+        VP_INFO(vp_utils::string_format("[%s] run done ok=%d frames=%u avg_fps=%.2f",
+                                        node_name.c_str(), ok ? 1 : 0, dec_frames, avg_fps));
+
+        cleanup();
+
+        if (!alive || quit) {
+            break;
+        }
+        if (!cycle) {
+            break;
+        }
+    }
+
+    this->out_queue.push(nullptr);
+    this->out_queue_semaphore.signal();
+}
+
+std::string vp_mpp_sdl_src_node::to_string() {
+    return file_path;
+}
+
+} // namespace vp_nodes

--- a/vp_node/nodes/vp_mpp_sdl_src_node.cpp
+++ b/vp_node/nodes/vp_mpp_sdl_src_node.cpp
@@ -802,7 +802,7 @@ bool vp_mpp_sdl_src_node::run_pipeline_once() {
                 av_packet_unref(filtered_packet);
             }
 
-            if (!quit && receive_ret != AVERROR(EAGAIN) && receive_ret != AVERROR_EOF) {
+            if (alive && !quit && receive_ret != AVERROR(EAGAIN) && receive_ret != AVERROR_EOF) {
                 VP_ERROR(vp_utils::string_format("[%s] av_bsf_receive_packet failed: %s",
                                                  node_name.c_str(), ff_err_to_string(receive_ret).c_str()));
                 av_packet_unref(input_packet);

--- a/vp_node/nodes/vp_mpp_sdl_src_node.h
+++ b/vp_node/nodes/vp_mpp_sdl_src_node.h
@@ -1,0 +1,260 @@
+#pragma once
+
+#include <string>
+
+#include <SDL2/SDL.h>
+#include <opencv2/core/core.hpp>
+
+#include "base/vp_src_node.h"
+
+extern "C" {
+#include <libavcodec/bsf.h>
+#include <libavformat/avformat.h>
+}
+
+#include "rockchip/mpp_buffer.h"
+#include "rockchip/rk_mpi.h"
+#include "rockchip/rk_mpi_cmd.h"
+#include "rockchip/rk_vdec_cfg.h"
+
+namespace vp_nodes {
+
+/**
+ * @brief 基于 MPP + SDL 的本地文件源节点。
+ *
+ * 该节点直接执行 MP4 demux + MPP 硬解 + SDL 渲染，避免 OpenCV VideoCapture/VideoWriter
+ * 桥接开销。可选将解码帧转换为 BGR 后下发 frame_meta。
+ */
+class vp_mpp_sdl_src_node : public vp_src_node {
+private:
+    // 输入文件路径。
+    std::string file_path;
+    // 是否循环播放。
+    bool cycle = true;
+    // 是否按源视频 FPS 节奏显示。
+    bool pace_by_src_fps = false;
+    // SDL 渲染是否启用 vsync。
+    bool enable_vsync = false;
+    // 是否禁用 FPS overlay。
+    bool disable_overlay = true;
+    // 是否全屏显示。
+    bool fullscreen = false;
+    // 是否渲染到屏幕。
+    bool render_to_screen = true;
+    // 是否向下游发布 frame_meta。
+    bool publish_frame_meta = false;
+    // SDL 视频驱动名称，空字符串表示自动选择。
+    std::string sdl_video_driver;
+    // SDL 渲染驱动名称，空字符串表示自动选择。
+    std::string sdl_render_driver;
+
+    // FFmpeg demux 上下文。
+    AVFormatContext* ifmt = nullptr;
+    // FFmpeg bsf 上下文。
+    AVBSFContext* ibsfc = nullptr;
+    // 视频流索引。
+    int video_index = -1;
+    // MPP 编码类型。
+    MppCodingType coding = MPP_VIDEO_CodingUnused;
+
+    // MPP 解码上下文。
+    MppCtx dec_ctx = nullptr;
+    // MPP API 句柄。
+    MppApi* dec_mpi = nullptr;
+    // MPP 复用 packet。
+    MppPacket dec_pkt = nullptr;
+    // MPP 输出帧缓冲组。
+    MppBufferGroup dec_frm_grp = nullptr;
+
+    // SDL 窗口句柄。
+    SDL_Window* sdl_window = nullptr;
+    // SDL 渲染器句柄。
+    SDL_Renderer* sdl_renderer = nullptr;
+    // SDL NV12 纹理句柄。
+    SDL_Texture* sdl_texture = nullptr;
+    // SDL 是否已初始化。
+    bool sdl_inited = false;
+
+    // 当前输出宽度。
+    int width = 0;
+    // 当前输出高度。
+    int height = 0;
+    // 水平 stride。
+    int stride_h = 0;
+    // 垂直 stride。
+    int stride_v = 0;
+
+    // 按源帧率节奏播放时的帧间隔(us)。
+    uint64_t frame_interval_us = 0;
+    // 播放开始时间(us)。
+    uint64_t play_start_us = 0;
+    // 已显示帧计数。
+    uint32_t shown_frames = 0;
+
+    // 解码帧计数。
+    uint32_t dec_frames = 0;
+    // FPS 统计起始时间(us)。
+    uint64_t fps_start_us = 0;
+    // 上次打印 FPS 的时间(us)。
+    uint64_t fps_last_log_us = 0;
+    // 上次打印 FPS 时帧计数。
+    uint32_t fps_last_log_frames = 0;
+
+    // UI 是否请求退出。
+    bool quit = false;
+
+private:
+    /**
+     * @brief 获取单调时钟微秒时间戳。
+     * @return uint64_t 当前微秒时间。
+     */
+    static uint64_t now_us();
+
+    /**
+     * @brief 把 FFmpeg codec id 映射为 MPP codec 与 bsf 名称。
+     * @param codec_id FFmpeg 编码类型。
+     * @param out_coding 输出 MPP 编码类型。
+     * @param out_bsf_name 输出 bsf 名称。
+     * @return true 映射成功；false 不支持。
+     */
+    static bool map_dec_codec(AVCodecID codec_id, MppCodingType& out_coding, const char*& out_bsf_name);
+
+    /**
+     * @brief 初始化 demux 与 bsf。
+     * @return true 初始化成功；false 失败。
+     */
+    bool init_demux();
+
+    /**
+     * @brief 初始化 MPP 解码器。
+     * @return true 初始化成功；false 失败。
+     */
+    bool init_decoder();
+
+    /**
+     * @brief 基于首帧信息初始化 SDL 渲染资源。
+     * @param frame MPP 输出帧。
+     * @return true 初始化成功；false 失败。
+     */
+    bool init_sdl_for_frame(MppFrame frame);
+
+    /**
+     * @brief 处理 SDL 事件。
+     */
+    void pump_sdl_events();
+
+    /**
+     * @brief 打印运行时 FPS。
+     */
+    void log_runtime_fps();
+
+    /**
+     * @brief 把 NV12 帧渲染到 SDL 窗口。
+     * @param frame MPP 输出帧。
+     * @return true 渲染成功；false 失败。
+     */
+    bool render_frame_nv12(MppFrame frame);
+
+    /**
+     * @brief 在 info change 阶段配置解码缓冲并初始化 SDL。
+     * @param frame MPP 输出帧。
+     * @return true 配置成功；false 失败。
+     */
+    bool setup_info_change(MppFrame frame);
+
+    /**
+     * @brief 把 NV12 帧转换为 BGR 并可选缩放，输出 frame_meta。
+     * @param frame MPP 输出帧。
+     */
+    void publish_frame_meta_if_needed(MppFrame frame);
+
+    /**
+     * @brief 处理单帧 decode 输出。
+     * @param frame MPP 输出帧。
+     * @param got_eos 是否收到 EOS。
+     * @return true 处理成功；false 失败。
+     */
+    bool process_decoded_frame(MppFrame frame, bool& got_eos);
+
+    /**
+     * @brief 拉取并处理解码器输出帧。
+     * @param got_eos 是否收到 EOS。
+     * @return true 成功；false 失败。
+     */
+    bool poll_decoder_frames(bool& got_eos);
+
+    /**
+     * @brief 重试向解码器提交 packet。
+     * @param got_eos 是否收到 EOS。
+     * @return true 成功；false 失败。
+     */
+    bool put_dec_packet_retry(bool& got_eos);
+
+    /**
+     * @brief 把码流 packet 发送到解码器。
+     * @param packet 输入 packet，可为空表示 flush。
+     * @param eos 当前 packet 是否为 EOS。
+     * @param got_eos 是否收到 EOS。
+     * @return true 成功；false 失败。
+     */
+    bool send_to_decoder(const AVPacket* packet, bool eos, bool& got_eos);
+
+    /**
+     * @brief 执行一次完整 demux+decode+render 流程。
+     * @return true 成功；false 失败。
+     */
+    bool run_pipeline_once();
+
+    /**
+     * @brief 释放 FFmpeg/MPP/SDL 资源。
+     */
+    void cleanup();
+
+protected:
+    /**
+     * @brief 源节点主循环。
+     */
+    virtual void handle_run() override;
+
+public:
+    /**
+     * @brief 构造 MPP+SDL 源节点。
+     * @param node_name 节点名称。
+     * @param channel_index 通道索引。
+     * @param file_path 输入 MP4 路径。
+     * @param cycle 是否循环播放。
+     * @param pace_by_src_fps 是否按源 FPS 节奏播放。
+     * @param enable_vsync SDL 是否启用 vsync。
+     * @param disable_overlay 是否关闭 overlay。
+     * @param fullscreen 是否全屏显示。
+     * @param render_to_screen 是否渲染到屏幕。
+     * @param publish_frame_meta 是否向下游发布 frame_meta。
+     * @param sdl_video_driver SDL 视频驱动名称（空表示自动）。
+     * @param sdl_render_driver SDL 渲染驱动名称（空表示自动）。
+     */
+    vp_mpp_sdl_src_node(std::string node_name,
+                        int channel_index,
+                        std::string file_path,
+                        bool cycle = true,
+                        bool pace_by_src_fps = false,
+                        bool enable_vsync = false,
+                        bool disable_overlay = true,
+                        bool fullscreen = false,
+                        bool render_to_screen = true,
+                        bool publish_frame_meta = false,
+                        std::string sdl_video_driver = "",
+                        std::string sdl_render_driver = "");
+
+    /**
+     * @brief 析构并释放资源。
+     */
+    ~vp_mpp_sdl_src_node();
+
+    /**
+     * @brief 返回节点描述字符串。
+     * @return std::string 输入文件路径。
+     */
+    virtual std::string to_string() override;
+};
+
+} // namespace vp_nodes

--- a/vp_node/nodes/vp_screen_des_node.cpp
+++ b/vp_node/nodes/vp_screen_des_node.cpp
@@ -1,8 +1,21 @@
 
 #include "vp_screen_des_node.h"
 #include "vp_utils/vp_utils.h"
+#include <atomic>
+#include <vector>
 
 namespace vp_nodes {
+    // screen_des 的全局退出请求标志。
+    static std::atomic<bool> g_screen_des_exit_requested{false};
+
+    bool vp_screen_des_should_exit() {
+        return g_screen_des_exit_requested.load();
+    }
+
+    void vp_screen_des_reset_exit_flag() {
+        g_screen_des_exit_requested.store(false);
+    }
+
     vp_screen_des_node::vp_screen_des_node(std::string node_name, 
                                             int channel_index, 
                                             bool osd,
@@ -14,6 +27,9 @@ namespace vp_nodes {
                                             display_w_h(display_w_h),
                                             fast_mode(fast_mode),
                                             video_sink(video_sink) {
+        if (this->video_sink == "opencv" || this->video_sink == "imshow") {
+            use_opencv_window = true;
+        }
         if (this->fast_mode) {
             this->gst_template = vp_utils::string_format(this->gst_template_fast, this->video_sink.c_str());
         }
@@ -25,6 +41,9 @@ namespace vp_nodes {
     }
     
     vp_screen_des_node::~vp_screen_des_node() {
+        // 注意：不在析构中主动 destroyWindow，避免在退出竞态阶段触发高 GUI 后端崩溃。
+        opencv_window_inited = false;
+        opencv_exit_requested = false;
         deinitialized();
     }
 
@@ -41,8 +60,76 @@ namespace vp_nodes {
                 resize_frame = (osd && !meta->osd_frame.empty()) ? meta->osd_frame : meta->frame;
             }
 
+            if (use_opencv_window) {
+                if (opencv_exit_requested) {
+                    return vp_des_node::handle_frame_meta(meta);
+                }
+                if (!opencv_window_inited) {
+                    cv::namedWindow(node_name, cv::WINDOW_NORMAL);
+                    opencv_window_inited = true;
+                    VP_INFO(vp_utils::string_format("[%s] open opencv window success.", node_name.c_str()));
+                }
+
+                // OpenCV 显示限帧：超过阈值的帧直接跳过显示，避免显示端拖慢整条处理链路。
+                if (opencv_display_fps_limit > 0) {
+                    const auto now_tp = std::chrono::steady_clock::now();
+                    const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(now_tp - opencv_last_display_tp).count();
+                    const int min_interval_ms = 1000 / opencv_display_fps_limit;
+                    if (elapsed_ms < min_interval_ms) {
+                        return vp_des_node::handle_frame_meta(meta);
+                    }
+                    opencv_last_display_tp = now_tp;
+                }
+
+                cv::imshow(node_name, resize_frame);
+                const int key = cv::waitKey(1) & 0xFF;  // 当前按键。
+                if (key == 27) {
+                    VP_INFO(vp_utils::string_format("[%s] ESC detected in opencv window, request exit.", node_name.c_str()));
+                    opencv_exit_requested = true;
+                    g_screen_des_exit_requested.store(true);
+                    return vp_des_node::handle_frame_meta(meta);
+                }
+                return vp_des_node::handle_frame_meta(meta);
+            }
+
             if (!screen_writer.isOpened()) {
-                assert(screen_writer.open(this->gst_template, cv::CAP_GSTREAMER, 0, meta->fps, {resize_frame.cols, resize_frame.rows}));
+                const double fps = (meta->fps > 0) ? static_cast<double>(meta->fps) : 25.0;  // 输出 FPS。
+                const cv::Size frame_size{resize_frame.cols, resize_frame.rows};  // 输出分辨率。
+                std::vector<std::string> candidates;  // 候选管线列表。
+                candidates.push_back(this->gst_template);
+                candidates.push_back(vp_utils::string_format(this->gst_template_fast, this->video_sink.c_str()));
+                candidates.push_back(vp_utils::string_format(this->gst_template_fallback, this->video_sink.c_str()));
+                candidates.push_back("appsrc ! videoconvert ! queue ! autovideosink");
+
+                for (auto& candidate : candidates) {
+                    if (candidate.empty()) {
+                        continue;
+                    }
+                    if (screen_writer.open(candidate, cv::CAP_GSTREAMER, 0, fps, frame_size)) {
+                        opened_gst_template = candidate;
+                        VP_INFO(vp_utils::string_format("[%s] open screen writer success: [%s], fps=%.2f, size=%dx%d",
+                                                        node_name.c_str(),
+                                                        opened_gst_template.c_str(),
+                                                        fps,
+                                                        frame_size.width,
+                                                        frame_size.height));
+                        break;
+                    }
+                }
+                if (!screen_writer.isOpened()) {
+                    if (!open_failed_logged) {
+                        VP_ERROR(vp_utils::string_format("[%s] open screen writer failed. sink=%s, fps=%.2f, size=%dx%d, first_pipeline=[%s]",
+                                                         node_name.c_str(),
+                                                         this->video_sink.c_str(),
+                                                         fps,
+                                                         frame_size.width,
+                                                         frame_size.height,
+                                                         this->gst_template.c_str()));
+                        open_failed_logged = true;
+                    }
+                    // 打不开显示时直接丢帧，后续继续重试 open。
+                    return vp_des_node::handle_frame_meta(meta);
+                }
             }
             screen_writer.write(resize_frame);
 

--- a/vp_node/nodes/vp_screen_des_node.cpp
+++ b/vp_node/nodes/vp_screen_des_node.cpp
@@ -6,11 +6,20 @@ namespace vp_nodes {
     vp_screen_des_node::vp_screen_des_node(std::string node_name, 
                                             int channel_index, 
                                             bool osd,
-                                            vp_objects::vp_size display_w_h):
+                                            vp_objects::vp_size display_w_h,
+                                            bool fast_mode,
+                                            std::string video_sink):
                                             vp_des_node(node_name, channel_index),
                                             osd(osd),
-                                            display_w_h(display_w_h) {
-        this->gst_template = vp_utils::string_format(this->gst_template, node_name.c_str());
+                                            display_w_h(display_w_h),
+                                            fast_mode(fast_mode),
+                                            video_sink(video_sink) {
+        if (this->fast_mode) {
+            this->gst_template = vp_utils::string_format(this->gst_template_fast, this->video_sink.c_str());
+        }
+        else {
+            this->gst_template = vp_utils::string_format(this->gst_template_normal, node_name.c_str(), this->video_sink.c_str());
+        }
         VP_INFO(vp_utils::string_format("[%s] [%s]", node_name.c_str(), gst_template.c_str()));
         this->initialized();
     }

--- a/vp_node/nodes/vp_screen_des_node.h
+++ b/vp_node/nodes/vp_screen_des_node.h
@@ -13,7 +13,10 @@ namespace vp_nodes {
     {
     private:
         /* data */
-        std::string gst_template = "appsrc ! videoconvert ! videoscale ! textoverlay text=%s halignment=left valignment=top font-desc='Sans,16' shaded-background=true ! timeoverlay halignment=right valignment=top font-desc='Sans,16' shaded-background=true ! queue ! fpsdisplaysink video-sink=ximagesink sync=false";
+        std::string gst_template_normal = "appsrc ! videoconvert ! videoscale ! textoverlay text=%s halignment=left valignment=top font-desc='Sans,16' shaded-background=true ! timeoverlay halignment=right valignment=top font-desc='Sans,16' shaded-background=true ! queue ! fpsdisplaysink video-sink=%s sync=false";
+        std::string gst_template_fast = "appsrc ! queue leaky=downstream max-size-buffers=2 ! videoconvert ! queue leaky=downstream max-size-buffers=2 ! fpsdisplaysink text-overlay=false video-sink=%s sync=false";
+        // 实际使用的 GStreamer 管线字符串。
+        std::string gst_template;
         cv::VideoWriter screen_writer;
     protected:
         // re-implementation, return nullptr.
@@ -24,12 +27,18 @@ namespace vp_nodes {
         vp_screen_des_node(std::string node_name, 
                             int channel_index, 
                             bool osd = true,
-                            vp_objects::vp_size display_w_h = {});
+                            vp_objects::vp_size display_w_h = {},
+                            bool fast_mode = false,
+                            std::string video_sink = "ximagesink");
         ~vp_screen_des_node();
 
         // for osd frame
         bool osd;
         // display size
         vp_objects::vp_size display_w_h;
+        // 是否开启快速显示模式（关闭 overlay，减少显示链路开销）。
+        bool fast_mode = false;
+        // 显示 sink 名称，默认 ximagesink，可按平台改为 xvimagesink/kmssink。
+        std::string video_sink = "ximagesink";
     };
 }

--- a/vp_node/nodes/vp_screen_des_node.h
+++ b/vp_node/nodes/vp_screen_des_node.h
@@ -3,11 +3,24 @@
 #pragma once
 
 #include <opencv2/core/core.hpp>
+#include <opencv2/highgui.hpp>
 #include <opencv2/imgproc.hpp>
 #include <opencv2/videoio.hpp>
+#include <chrono>
 #include "base/vp_des_node.h"
 
 namespace vp_nodes {
+    /**
+     * @brief 查询 screen_des 是否请求退出（由 OpenCV 窗口 ESC/关闭触发）。
+     * @return true 请求退出；false 未请求。
+     */
+    bool vp_screen_des_should_exit();
+
+    /**
+     * @brief 重置 screen_des 退出请求标志。
+     */
+    void vp_screen_des_reset_exit_flag();
+
     // screen des node, display video on local window.
     class vp_screen_des_node: public vp_des_node
     {
@@ -15,9 +28,25 @@ namespace vp_nodes {
         /* data */
         std::string gst_template_normal = "appsrc ! videoconvert ! videoscale ! textoverlay text=%s halignment=left valignment=top font-desc='Sans,16' shaded-background=true ! timeoverlay halignment=right valignment=top font-desc='Sans,16' shaded-background=true ! queue ! fpsdisplaysink video-sink=%s sync=false";
         std::string gst_template_fast = "appsrc ! queue leaky=downstream max-size-buffers=2 ! videoconvert ! queue leaky=downstream max-size-buffers=2 ! fpsdisplaysink text-overlay=false video-sink=%s sync=false";
+        // 降级使用的最简显示管线（直接走 sink）。
+        std::string gst_template_fallback = "appsrc ! videoconvert ! videoscale ! queue ! %s";
         // 实际使用的 GStreamer 管线字符串。
         std::string gst_template;
+        // 实际打开成功的 GStreamer 管线字符串。
+        std::string opened_gst_template;
         cv::VideoWriter screen_writer;
+        // 是否已经打印过 open 失败日志，避免刷屏。
+        bool open_failed_logged = false;
+        // 是否使用 OpenCV imshow 显示。
+        bool use_opencv_window = false;
+        // OpenCV 窗口是否已初始化。
+        bool opencv_window_inited = false;
+        // OpenCV 窗口是否已请求退出。
+        bool opencv_exit_requested = false;
+        // OpenCV 显示限帧（0 表示不限速）。
+        int opencv_display_fps_limit = 30;
+        // 上次 OpenCV 实际显示时间点。
+        std::chrono::steady_clock::time_point opencv_last_display_tp = std::chrono::steady_clock::now();
     protected:
         // re-implementation, return nullptr.
         virtual std::shared_ptr<vp_objects::vp_meta> handle_frame_meta(std::shared_ptr<vp_objects::vp_frame_meta> meta) override; 

--- a/vp_node/vp_utils/analysis_board/vp_node_on_screen.cpp
+++ b/vp_node/vp_utils/analysis_board/vp_node_on_screen.cpp
@@ -254,6 +254,8 @@ namespace vp_utils {
         auto node_top = node_rect.y;
         // stream info at src nodes
         if (original_node->node_type() == vp_nodes::vp_node_type::SRC) {
+            // 解码 FPS 文本（来自源节点输出端口的实时统计）。
+            std::string decode_fps_text = meta_leaving_hooker_storage.pre_fps.empty() ? "0" : meta_leaving_hooker_storage.pre_fps;
             vp_utils::put_text_at_center_of_rect(canvas, stream_info_hooker_storage.uri, 
                                                 cv::Rect(node_left - node_rect.width * 3 / 4, node_top + node_title_h + node_queue_port_padding, node_rect.width * 4 / 3, node_title_h * 2 / 3), 
                                                 true, font_face, 1, cv::Scalar(), cv::Scalar(), cv::Scalar(255, 255, 255));
@@ -266,13 +268,16 @@ namespace vp_utils {
             vp_utils::put_text_at_center_of_rect(canvas, "original_fps: " + std::to_string(stream_info_hooker_storage.original_fps),
                                                 cv::Rect(node_left - node_rect.width * 3 / 4, node_top + node_title_h * 9 / 3 + node_queue_port_padding * 4, node_rect.width * 4 / 3, node_title_h * 2 / 3),
                                                 true, font_face, 1, cv::Scalar(), cv::Scalar(), cv::Scalar(255, 255, 255));   
+            vp_utils::put_text_at_center_of_rect(canvas, "decode_fps: " + decode_fps_text,
+                                                cv::Rect(node_left - node_rect.width * 3 / 4, node_top + node_title_h * 11 / 3 + node_queue_port_padding * 5, node_rect.width * 4 / 3, node_title_h * 2 / 3),
+                                                true, font_face, 1, cv::Scalar(), cv::Scalar(), cv::Scalar(255, 255, 255));   
         } 
         // stream status at des nodes
         if (original_node->node_type() == vp_nodes::vp_node_type::DES) {
             vp_utils::put_text_at_center_of_rect(canvas, stream_status_hooker_storage.direction,
                                                 cv::Rect(node_left + node_rect.width / 2 - 10, node_top + node_title_h * 5 / 3 + node_queue_port_padding * 2, node_rect.width * 4 / 3 + 10, node_title_h * 2 / 3),
                                                 true,font_face,1,cv::Scalar(),cv::Scalar(),cv::Scalar(255, 255, 255));    
-            vp_utils::put_text_at_center_of_rect(canvas, "output_fps: " + vp_utils::round_any(stream_status_hooker_storage.fps, 2),
+            vp_utils::put_text_at_center_of_rect(canvas, "encode_fps: " + vp_utils::round_any(stream_status_hooker_storage.fps, 2),
                                                 cv::Rect(node_left + node_rect.width / 2 - 10, node_top + node_title_h * 7 / 3 + node_queue_port_padding * 3, node_rect.width * 4 / 3 + 10, node_title_h * 2 / 3),
                                                 true,font_face,1,cv::Scalar(),cv::Scalar(),cv::Scalar(255, 255, 255));   
             vp_utils::put_text_at_center_of_rect(canvas, "latency: " + std::to_string(stream_status_hooker_storage.latency) + "ms",


### PR DESCRIPTION
## Summary
- Add complete YOLO26 object detection integration to the RK_VideoPipe framework
- Add node FPS logging for performance monitoring  
- Enhance display handling with OpenCV window support and GStreamer fallback

## Changes
- **New YOLO26 model**: Added `yolo26.cpp/h`, `yolo26_post.cpp/h`, and `assets/configs/yolo26.json`
- **New inference node**: Added `vp_rk_first_yolo26.cpp/h` primary inference node
- **Enhanced pipeline**: Updated main.cc to use MPP -> YOLO26 -> OSD -> screen display flow
- **FPS monitoring**: Added periodic FPS logging in `vp_node::log_node_fps_if_needed()`
- **Display improvements**: 
  - OpenCV imshow window support with ESC exit detection
  - GStreamer pipeline fallback candidates for better compatibility
  - Display FPS limiting to avoid pipeline bottlenecks
- **Exit handling**: Terminal ESC key detection + global screen_des exit flag

## Test plan
- [ ] Run pipeline with sample video to verify YOLO26 detection works
- [ ] Test ESC key exit from both terminal and OpenCV window
- [ ] Verify FPS logging shows reasonable metrics
- [ ] Test GStreamer fallback on different display configurations

🤖 Generated with [Claude Code](https://claude.com/claude-code)